### PR TITLE
Use Box::{into_raw, from_raw} instead of mem::transmute.

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -17,17 +17,14 @@ use read_box;
 #[no_mangle]
 pub extern "C" fn mp4parse_new() -> *mut MediaContext {
     let context = Box::new(MediaContext::new());
-    unsafe {
-        // transmute is unsafe, but context is always valid.
-        std::mem::transmute(context)
-    }
+    Box::into_raw(context)
 }
 
 /// Free a rust-side parser context.
 #[no_mangle]
 pub unsafe extern "C" fn mp4parse_free(context: *mut MediaContext) {
     assert!(!context.is_null());
-    let _: Box<MediaContext> = std::mem::transmute(context);
+    let _ = Box::from_raw(context);
 }
 
 /// Feed a buffer through read_box(), returning the number of detected tracks.


### PR DESCRIPTION
These methods, stabilized in rustc 1.4, reflect what we want
to do more accurately, including the safety of mp4parse_new(),
and are more succinct.

Thanks to Simon Sapin for the suggestion.