### PR TITLE
Regularize capi functions

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -41,11 +41,13 @@ use MediaContext;
 use TrackType;
 use read_mp4;
 use Error;
-use media_time_to_ms;
-use track_time_to_ms;
 use SampleEntry;
 use AudioCodecSpecific;
 use VideoCodecSpecific;
+use MediaTimeScale;
+use MediaScaledTime;
+use TrackTimeScale;
+use TrackScaledTime;
 use serialize_opus_header;
 
 // rusty-cheddar's C enum generation doesn't namespace enum members by
@@ -271,6 +273,17 @@ pub unsafe extern fn mp4parse_get_track_count(parser: *const mp4parse_parser, co
     }
     *count = context.tracks.len() as u32;
     MP4PARSE_OK
+}
+
+fn media_time_to_ms(time: MediaScaledTime, scale: MediaTimeScale) -> u64 {
+    assert!(scale.0 != 0);
+    time.0 * 1000000 / scale.0
+}
+
+fn track_time_to_ms(time: TrackScaledTime, scale: TrackTimeScale) -> u64 {
+    assert!(time.1 == scale.1);
+    assert!(scale.0 != 0);
+    time.0 * 1000000 / scale.0
 }
 
 /// Fill the supplied `mp4parse_track_info` with metadata for `track`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1338,17 +1338,6 @@ fn read_fixed_length_pascal_string<T: Read>(src: &mut T, size: usize) -> Result<
     String::from_utf8(buf).map_err(From::from)
 }
 
-fn media_time_to_ms(time: MediaScaledTime, scale: MediaTimeScale) -> u64 {
-    assert!(scale.0 != 0);
-    time.0 * 1000000 / scale.0
-}
-
-fn track_time_to_ms(time: TrackScaledTime, scale: TrackTimeScale) -> u64 {
-    assert!(time.1 == scale.1);
-    assert!(scale.0 != 0);
-    time.0 * 1000000 / scale.0
-}
-
 fn be_i16<T: ReadBytesExt>(src: &mut T) -> Result<i16> {
     src.read_i16::<byteorder::BigEndian>().map_err(From::from)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1020,7 +1020,7 @@ fn read_dops<T: Read>(src: &mut BMFFBox<T>) -> Result<OpusSpecificBox> {
 /// Ogg and WebM encapsulations. To support this we prepend the `OpusHead`
 /// tag and byte-swap the data from big- to little-endian relative to the
 /// dOps box.
-fn serialize_opus_header<W: byteorder::WriteBytesExt + std::io::Write>(opus: &OpusSpecificBox, dst: &mut W) -> Result<()> {
+pub fn serialize_opus_header<W: byteorder::WriteBytesExt + std::io::Write>(opus: &OpusSpecificBox, dst: &mut W) -> Result<()> {
     match dst.write(b"OpusHead") {
         Err(e) => return Err(Error::from(e)),
         Ok(bytes) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::io::Cursor;
-use super::*;
+use super::read_mp4;
+use super::MediaContext;
+use super::Error;
 extern crate test_assembler;
 use self::test_assembler::*;
 


### PR DESCRIPTION
As part of making some things public, move capi-only helpers into capi.rs.