### PR TITLE
Use checked arithmetic in time_to_us.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -291,19 +291,21 @@ impl Default for TrackType {
     fn default() -> Self { TrackType::Unknown }
 }
 
-/// The media's global (mvhd) timescale.
+/// The media's global (mvhd) timescale in units per second.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MediaTimeScale(pub u64);
 
-/// A time scaled by the media's global (mvhd) timescale.
+/// A time to be scaled by the media's global (mvhd) timescale.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MediaScaledTime(pub u64);
 
 /// The track's local (mdhd) timescale.
+/// Members are timescale units per second and the track id.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TrackTimeScale(pub u64, pub usize);
 
-/// A time scaled by the track's local (mdhd) timescale.
+/// A time to be scaled by the track's local (mdhd) timescale.
+/// Members are time in scale units and the track id.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TrackScaledTime(pub u64, pub usize);
 


### PR DESCRIPTION
Since movie and track durations and media times can be 64-bit
integers, converting them to microseconds can overflow. Fortunately
our runtime error checking caught an instance of this.

Change the return type of the conversion routines to an Option and
use checked artimetic. In get_track_info default to 0 for overflowing
media_time and return an error for overflowing duration. This is
sufficient to accept the triggering content.

Rename time_to_ms to time_to_us to clarify that they return times
in microseconds.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1301065