### PR TITLE
Parse mvex to retrieve fragment_duration.

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -55,4 +55,5 @@ box_database!(
     ProtectedVisualSampleEntry 0x656e6376, // "encv" - Need to check official name in spec.
     ProtectedAudioSampleEntry  0x656e6361, // "enca" - Need to check official name in spec.
     MovieExtendsBox            0x6d766578, // "mvex"
+    MovieExtendsHeaderBox      0x6d656864, // "mehd"
 );

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -137,6 +137,13 @@ pub struct mp4parse_track_video_info {
     // codec_specific_config
 }
 
+#[repr(C)]
+pub struct mp4parse_fragment_info {
+    pub fragment_duration: u64,
+    // TODO:
+    // info in trex box.
+}
+
 // Even though mp4parse_parser is opaque to C, rusty-cheddar won't let us
 // use more than one member, so we introduce *another* wrapper.
 struct Wrap {
@@ -492,6 +499,32 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
     MP4PARSE_OK
 }
 
+#[no_mangle]
+pub unsafe extern fn mp4parse_get_fragment_info(parser: *mut mp4parse_parser, info: *mut mp4parse_fragment_info) -> mp4parse_error {
+    if parser.is_null() || info.is_null() || (*parser).poisoned() {
+        return MP4PARSE_ERROR_BADARG;
+    }
+
+    let context = (*parser).context();
+    let info: &mut mp4parse_fragment_info = &mut *info;
+
+    info.fragment_duration = 0;
+
+    let duration = match context.mvex {
+        Some(ref mvex) => mvex.fragment_duration,
+        None => return MP4PARSE_ERROR_INVALID,
+    };
+
+    if let (Some(time), Some(scale)) = (duration, context.timescale) {
+        info.fragment_duration = match media_time_to_us(time, scale) {
+            Some(time_us) => time_us as u64,
+            None => return MP4PARSE_ERROR_INVALID,
+        }
+    }
+
+    MP4PARSE_OK
+}
+
 // A fragmented file needs mvex table and contains no data in stts, stsc, and stco boxes.
 #[no_mangle]
 pub unsafe extern fn mp4parse_is_fragmented(parser: *mut mp4parse_parser, track_id: u32, fragmented: *mut u8) -> mp4parse_error {
@@ -503,7 +536,7 @@ pub unsafe extern fn mp4parse_is_fragmented(parser: *mut mp4parse_parser, track_
     let tracks = &context.tracks;
     (*fragmented) = false as u8;
 
-    if !context.has_mvex {
+    if context.mvex.is_none() {
         return MP4PARSE_OK;
     }
 


### PR DESCRIPTION
Parse fragment_duration for https://bugzilla.mozilla.org/show_bug.cgi?id=1304254.

Test will be added in another PR later.