### PR TITLE
Parse quicktime audio sample entry

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -58,4 +58,5 @@ box_database!(
     ProtectedAudioSampleEntry  0x656e6361, // "enca" - Need to check official name in spec.
     MovieExtendsBox            0x6d766578, // "mvex"
     MovieExtendsHeaderBox      0x6d656864, // "mehd"
+    QTWaveAtom                 0x77617665, // "wave" - quicktime atom
 );


### PR DESCRIPTION
 Parse quicktime audio sample entry format.

Quicktime uses a 'wave' atom in audio sample entry box. For 'mp4a', its
'esds' is inside 'wave' atom. That is:
mp4a {
|--- wave {
|------- esds {
|------- }
|--- }
}

Detail spec can be found at: http://multimedia.cx/mirror/qtff-2007-09-04.pdf

Patch summaries:
1. rename read_audio_desc() and read_video_desc() to read_audio_sample_entry() and read_video_sample_entry().
2. move esds codes to function read_esds().
3. add read_qt_wave_atom() to parse qt wave atom.
4. check qt version in read_audio_sample_entry().

I think we also need to parse QT video sample entry? Maybe later.

https://bugzilla.mozilla.org/show_bug.cgi?id=1307045