### PR TITLE
Parse ESDS.

### DIFF
--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -826,7 +826,14 @@ fn skip_padding_in_stsd() {
 #[test]
 fn read_qt_wave_atom() {
     let esds = make_fullbox(BoxSize::Auto, b"esds", 0, |s| {
-        s.append_repeated(0, 30)
+        s.B8(0x03)  // elementary stream descriptor tag
+         .B8(0x0b)  // esds length
+         .append_repeated(0, 2)
+         .B8(0x00)  // flags
+         .B8(0x04)  // decoder config descriptor tag
+         .B8(0x06)  // dcds length
+         .B8(0x6b)  // mp3
+         .append_repeated(0, 5)
     }).into_inner();
     let wave = make_box(BoxSize::Auto, b"wave", |s| {
         s.append_bytes(esds.as_slice())
@@ -849,4 +856,5 @@ fn read_qt_wave_atom() {
     let mut track = super::Track::new(0);
     super::read_audio_sample_entry(&mut stream, &mut track)
           .expect("fail to read qt wave atom");
+    assert_eq!(track.codec_type, super::CodecType::MP3);
 }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -70,7 +70,7 @@ fn public_api() {
 
                 // track.data part
                 assert_eq!(match a.codec_specific {
-                    mp4::AudioCodecSpecific::EsDescriptor(esds) => {
+                    mp4::AudioCodecSpecific::ES_Descriptor(esds) => {
                         assert_eq!(esds.audio_codec, mp4::CodecType::AAC);
                         "ES"
                     }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -70,8 +70,8 @@ fn public_api() {
 
                 // track.data part
                 assert_eq!(match a.codec_specific {
-                    mp4::AudioCodecSpecific::ES_Descriptor(v) => {
-                        assert!(v.len() > 0);
+                    mp4::AudioCodecSpecific::EsDescriptor(esds) => {
+                        assert_eq!(esds.audio_codec, mp4::CodecType::AAC);
                         "ES"
                     }
                     mp4::AudioCodecSpecific::FLACSpecificBox(_) => {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -52,6 +52,7 @@ use mp4parse::MediaScaledTime;
 use mp4parse::TrackTimeScale;
 use mp4parse::TrackScaledTime;
 use mp4parse::serialize_opus_header;
+use mp4parse::CodecType;
 
 // rusty-cheddar's C enum generation doesn't namespace enum members by
 // prefixing them, so we're forced to do it in our member names until
@@ -88,6 +89,7 @@ pub enum mp4parse_codec {
     MP4PARSE_CODEC_OPUS,
     MP4PARSE_CODEC_AVC,
     MP4PARSE_CODEC_VP9,
+    MP4PARSE_CODEC_MP3,
 }
 
 #[repr(C)]
@@ -345,8 +347,12 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
                 mp4parse_codec::MP4PARSE_CODEC_OPUS,
             AudioCodecSpecific::FLACSpecificBox(_) =>
                 mp4parse_codec::MP4PARSE_CODEC_FLAC,
-            AudioCodecSpecific::ES_Descriptor(_) =>
+            AudioCodecSpecific::EsDescriptor(ref esds) if esds.audio_codec == CodecType::AAC =>
                 mp4parse_codec::MP4PARSE_CODEC_AAC,
+            AudioCodecSpecific::EsDescriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
+                mp4parse_codec::MP4PARSE_CODEC_MP3,
+            AudioCodecSpecific::EsDescriptor(_) =>
+                mp4parse_codec::MP4PARSE_CODEC_UNKNOWN,
         },
         Some(SampleEntry::Video(ref video)) => match video.codec_specific {
             VideoCodecSpecific::VPxConfig(_) =>
@@ -432,12 +438,12 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
     (*info).sample_rate = audio.samplerate >> 16; // 16.16 fixed point
 
     match audio.codec_specific {
-        AudioCodecSpecific::ES_Descriptor(ref v) => {
-            if v.len() > std::u32::MAX as usize {
+        AudioCodecSpecific::EsDescriptor(ref v) => {
+            if v.codec_specific_config.len() > std::u32::MAX as usize {
                 return MP4PARSE_ERROR_INVALID;
             }
-            (*info).codec_specific_config.length = v.len() as u32;
-            (*info).codec_specific_config.data = v.as_ptr();
+            (*info).codec_specific_config.length = v.codec_specific_config.len() as u32;
+            (*info).codec_specific_config.data = v.codec_specific_config.as_ptr();
         }
         AudioCodecSpecific::FLACSpecificBox(_) => {
             return MP4PARSE_ERROR_UNSUPPORTED;

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -347,11 +347,11 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
                 mp4parse_codec::MP4PARSE_CODEC_OPUS,
             AudioCodecSpecific::FLACSpecificBox(_) =>
                 mp4parse_codec::MP4PARSE_CODEC_FLAC,
-            AudioCodecSpecific::EsDescriptor(ref esds) if esds.audio_codec == CodecType::AAC =>
+            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::AAC =>
                 mp4parse_codec::MP4PARSE_CODEC_AAC,
-            AudioCodecSpecific::EsDescriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
+            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
                 mp4parse_codec::MP4PARSE_CODEC_MP3,
-            AudioCodecSpecific::EsDescriptor(_) =>
+            AudioCodecSpecific::ES_Descriptor(_) =>
                 mp4parse_codec::MP4PARSE_CODEC_UNKNOWN,
         },
         Some(SampleEntry::Video(ref video)) => match video.codec_specific {
@@ -438,7 +438,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
     (*info).sample_rate = audio.samplerate >> 16; // 16.16 fixed point
 
     match audio.codec_specific {
-        AudioCodecSpecific::EsDescriptor(ref v) => {
+        AudioCodecSpecific::ES_Descriptor(ref v) => {
             if v.codec_specific_config.len() > std::u32::MAX as usize {
                 return MP4PARSE_ERROR_INVALID;
             }


### PR DESCRIPTION
Structure of ESDS:

  ESDS box
   |
   |- ES descriptor
   |   |- 3 bytes extension (optional)
   |   |- 1 byte length
   |   |- 2 bytes ES ID
   |   |- 1 byte stream priority and flags
   |   |- stream dependency (optional, depends on flags)
   |   |   |- 2 bytes
   |   |- url (optional, depends on flags)
   |   |   |- 1 byte length
   |   |   |- x bytes, x is the length
   |   |
   |   |- Decoder Config descriptior
   |   |- 3 bytes extension (optional)
   |   |- 1 byte length
   |   |- 1 byte object profile indicator

We need to get object profile indicator for the codec type.