### PR TITLE
check channelcounts in CSD

### DIFF
--- a/mp4parse_capi/examples/test.cc
+++ b/mp4parse_capi/examples/test.cc
@@ -166,7 +166,7 @@ void test_arg_validation_with_data(const std::string& filename)
   memset(&audio, 0, sizeof(audio));
   rv = mp4parse_get_track_audio_info(parser, 1, &audio);
   assert(rv == MP4PARSE_OK);
-  assert(audio.channels == 2);
+  assert(audio.channels == 1);
   assert(audio.bit_depth == 16);
   assert(audio.sample_rate == 48000);
 

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -447,6 +447,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
             if let Some(rate) = v.audio_sample_rate {
                 (*info).sample_rate = rate;
             }
+            if let Some(channels) = v.audio_channel_count {
+                (*info).channels = channels;
+            }
         }
         AudioCodecSpecific::FLACSpecificBox(_) => {
             return MP4PARSE_ERROR_UNSUPPORTED;
@@ -792,7 +795,7 @@ fn arg_validation_with_data() {
 
         let mut audio = Default::default();
         assert_eq!(MP4PARSE_OK, mp4parse_get_track_audio_info(parser, 1, &mut audio));
-        assert_eq!(audio.channels, 2);
+        assert_eq!(audio.channels, 1);
         assert_eq!(audio.bit_depth, 16);
         assert_eq!(audio.sample_rate, 48000);
 


### PR DESCRIPTION
Audio channel count in ESDS is different comparing to AudioSampleEntry for Facebook video. Stagefright uses audio channel count from ESDS.
So MP4 rust parser should be able to retrieve it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1311929