### PR TITLE
Support multiple sinf boxes

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1739,6 +1739,9 @@ fn read_schi<T: Read>(src: &mut BMFFBox<T>) -> Result<Option<TrackEncryptionBox>
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
             BoxType::TrackEncryptionBox => {
+                if tenc.is_some() {
+                    return Err(Error::InvalidData("tenc box should be only one at most in sinf box"));
+                }
                 tenc = Some(read_tenc(&mut b)?);
             },
             _ => skip_box_content(&mut b)?,

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -228,7 +228,7 @@ pub struct AudioSampleEntry {
     pub samplesize: u16,
     pub samplerate: u32,
     pub codec_specific: AudioCodecSpecific,
-    pub protection_info: Option<ProtectionSchemeInfoBox>,
+    pub protection_info: Vec<ProtectionSchemeInfoBox>,
 }
 
 #[derive(Debug, Clone)]
@@ -243,7 +243,7 @@ pub struct VideoSampleEntry {
     pub width: u16,
     pub height: u16,
     pub codec_specific: VideoCodecSpecific,
-    pub protection_info: Option<ProtectionSchemeInfoBox>,
+    pub protection_info: Vec<ProtectionSchemeInfoBox>,
 }
 
 /// Represent a Video Partition Codec Configuration 'vpcC' box (aka vp9).
@@ -318,7 +318,7 @@ pub struct TrackEncryptionBox {
 #[derive(Debug, Default, Clone)]
 pub struct ProtectionSchemeInfoBox {
     pub code_name: String,
-    pub tenc: TrackEncryptionBox,
+    pub tenc: Option<TrackEncryptionBox>,
 }
 
 /// Internal data structures.
@@ -1491,7 +1491,7 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
 
     // Skip clap/pasp/etc. for now.
     let mut codec_specific = None;
-    let mut protection_info = None;
+    let mut protection_info = Vec::new();
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
@@ -1526,7 +1526,7 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                 }
                 let sinf = read_sinf(&mut b)?;
                 log!("{:?} (sinf)", sinf);
-                protection_info = Some(sinf);
+                protection_info.push(sinf);
             }
             _ => skip_box_content(&mut b)?,
         }
@@ -1598,7 +1598,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
 
     // Skip chan/etc. for now.
     let mut codec_specific = None;
-    let mut protection_info = None;
+    let mut protection_info = Vec::new();
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
@@ -1643,7 +1643,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                 let sinf = read_sinf(&mut b)?;
                 log!("{:?} (sinf)", sinf);
                 track.codec_type = CodecType::EncryptedAudio;
-                protection_info = Some(sinf);
+                protection_info.push(sinf);
             }
             _ => skip_box_content(&mut b)?,
         }
@@ -1714,45 +1714,38 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleD
 fn read_sinf<T: Read>(src: &mut BMFFBox<T>) -> Result<ProtectionSchemeInfoBox> {
     let mut sinf = ProtectionSchemeInfoBox::default();
 
-    let mut has_frma_schi_boxes = (false, false);
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
             BoxType::OriginalFormatBox => {
                 let frma = read_frma(&mut b)?;
                 sinf.code_name = frma;
-                has_frma_schi_boxes.0 = true;
             },
             BoxType::SchemeInformationBox => {
                 // We only need tenc box in schi box so far.
-                let schi_tenc = read_schi(&mut b)?;
-                sinf.tenc = schi_tenc;
-                has_frma_schi_boxes.1 = true
+                sinf.tenc = read_schi(&mut b)?;
             },
             _ => skip_box_content(&mut b)?,
         }
         check_parser_state!(b.content);
     }
 
-    if has_frma_schi_boxes != (true, true) {
-        return Err(Error::InvalidData("malformat sinf box"));
-    }
-
     Ok(sinf)
 }
 
-fn read_schi<T: Read>(src: &mut BMFFBox<T>) -> Result<TrackEncryptionBox> {
+fn read_schi<T: Read>(src: &mut BMFFBox<T>) -> Result<Option<TrackEncryptionBox>> {
+    let mut tenc = None;
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
             BoxType::TrackEncryptionBox => {
-                return read_tenc(&mut b);
+                tenc = Some(read_tenc(&mut b)?);
             },
             _ => skip_box_content(&mut b)?,
         }
     }
 
-    Err(Error::InvalidData("malformed schi box"))
+    Ok(tenc)
 }
 
 fn read_tenc<T: Read>(src: &mut BMFFBox<T>) -> Result<TrackEncryptionBox> {

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -117,14 +117,19 @@ fn public_audio_tenc() {
         assert_eq!(track.codec_type, mp4::CodecType::EncryptedAudio);
         match track.data {
             Some(mp4::SampleEntry::Audio(a)) => {
-                match a.protection_info {
-                    Some(p) => {
+                match a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+                    Some(ref p) => {
                         assert_eq!(p.code_name, "mp4a");
-                        assert!(p.tenc.is_encrypted > 0);
-                        assert!(p.tenc.iv_size ==  16);
-                        assert!(p.tenc.kid == kid);
+                        if let Some(ref tenc) = p.tenc {
+                            assert!(tenc.is_encrypted > 0);
+                            assert!(tenc.iv_size ==  16);
+                            assert!(tenc.kid == kid);
+                        } else {
+                            // something is wrong in your patch...
+                            assert!(false);
+                        }
                     },
-                    _ => {
+                    _=> {
                         // something is wrong in your patch...
                         assert!(false);
                     },
@@ -168,14 +173,19 @@ fn public_video_cenc() {
         assert_eq!(track.codec_type, mp4::CodecType::EncryptedVideo);
         match track.data {
             Some(mp4::SampleEntry::Video(v)) => {
-                match v.protection_info {
-                    Some(p) => {
+                match v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+                    Some(ref p) => {
                         assert_eq!(p.code_name, "avc1");
-                        assert!(p.tenc.is_encrypted > 0);
-                        assert!(p.tenc.iv_size ==  16);
-                        assert!(p.tenc.kid == kid);
+                        if let Some(ref tenc) = p.tenc {
+                            assert!(tenc.is_encrypted > 0);
+                            assert!(tenc.iv_size ==  16);
+                            assert!(tenc.kid == kid);
+                        } else {
+                            // something is wrong in your patch...
+                            assert!(false);
+                        }
                     },
-                    _ => {
+                    _=> {
                         // something is wrong in your patch...
                         assert!(false);
                     },

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -125,19 +125,16 @@ fn public_audio_tenc() {
                             assert!(tenc.iv_size ==  16);
                             assert!(tenc.kid == kid);
                         } else {
-                            // something is wrong in your patch...
-                            assert!(false);
+                            assert!(false, "Invalid test condition");
                         }
                     },
                     _=> {
-                        // something is wrong in your patch...
-                        assert!(false);
+                        assert!(false, "Invalid test condition");
                     },
                 }
             },
             _ => {
-                // something is wrong in your patch...
-                assert!(false);
+                assert!(false, "Invalid test condition");
             }
         }
     }
@@ -181,19 +178,16 @@ fn public_video_cenc() {
                             assert!(tenc.iv_size ==  16);
                             assert!(tenc.kid == kid);
                         } else {
-                            // something is wrong in your patch...
-                            assert!(false);
+                            assert!(false, "Invalid test condition");
                         }
                     },
                     _=> {
-                        // something is wrong in your patch...
-                        assert!(false);
+                        assert!(false, "Invalid test condition");
                     },
                 }
             },
             _ => {
-                // something is wrong in your patch...
-                assert!(false);
+                assert!(false, "Invalid test condition");
             }
         }
     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -513,13 +513,15 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
         }
     }
 
-    match audio.protection_info {
-        Some(ref protected) => {
-            (*info).protected_data.is_encrypted = protected.tenc.is_encrypted;
-            (*info).protected_data.iv_size = protected.tenc.iv_size;
-            (*info).protected_data.kid.set_data(&(protected.tenc.kid));
+    match audio.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+        Some(ref p) => {
+            if let Some(ref tenc) = p.tenc {
+                (*info).protected_data.is_encrypted = tenc.is_encrypted;
+                (*info).protected_data.iv_size = tenc.iv_size;
+                (*info).protected_data.kid.set_data(&(tenc.kid));
+            }
         },
-        _ => {},
+        _=> {},
     }
 
     MP4PARSE_OK
@@ -571,13 +573,15 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
         _ => {},
     }
 
-    match video.protection_info {
-        Some(ref protected) => {
-            (*info).protected_data.is_encrypted = protected.tenc.is_encrypted;
-            (*info).protected_data.iv_size = protected.tenc.iv_size;
-            (*info).protected_data.kid.set_data(&(protected.tenc.kid));
+    match video.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+        Some(ref p) => {
+            if let Some(ref tenc) = p.tenc {
+                (*info).protected_data.is_encrypted = tenc.is_encrypted;
+                (*info).protected_data.iv_size = tenc.iv_size;
+                (*info).protected_data.kid.set_data(&(tenc.kid));
+            }
         },
-        _ => {},
+        _=> {},
     }
 
     MP4PARSE_OK

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -521,7 +521,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
                 (*info).protected_data.kid.set_data(&(tenc.kid));
             }
         },
-        _=> {},
+        _ => {},
     }
 
     MP4PARSE_OK
@@ -581,7 +581,7 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
                 (*info).protected_data.kid.set_data(&(tenc.kid));
             }
         },
-        _=> {},
+        _ => {},
     }
 
     MP4PARSE_OK


### PR DESCRIPTION
According  to spec 14496-12, it could be multiple sinf boxes in stream. And I found this case exists in [1] and [2].
And tenc box is optional, sinf doesn't always contain tenc which case found in [1] and [2].

[1] http://shaka-player-demo.appspot.com/demo/  (car clear key)
[2] https://www.netflix.com