### PR TITLE
parse audio object type in esds

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -208,6 +208,7 @@ pub enum SampleEntry {
 #[derive(Debug, Clone, Default)]
 pub struct ES_Descriptor {
     pub audio_codec: CodecType,
+    pub audio_object_type: Option<u16>,
     pub audio_sample_rate: Option<u32>,
     pub audio_channel_count: Option<u16>,
     pub codec_esds: Vec<u8>,
@@ -1248,6 +1249,8 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 
     let audio_specific_config = be_u16(des)?;
 
+    let audio_object_type = audio_specific_config >> 11;
+
     let sample_index = (audio_specific_config & 0x07FF) >> 7;
 
     let channel_counts = (audio_specific_config & 0x007F) >> 3;
@@ -1255,6 +1258,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     let sample_frequency =
         frequency_table.iter().find(|item| item.0 == sample_index).map(|x| x.1);
 
+    esds.audio_object_type = Some(audio_object_type);
     esds.audio_sample_rate = sample_frequency;
     esds.audio_channel_count = Some(channel_counts);
 

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -77,6 +77,7 @@ fn public_api() {
                     mp4::AudioCodecSpecific::ES_Descriptor(esds) => {
                         assert_eq!(esds.audio_codec, mp4::CodecType::AAC);
                         assert_eq!(esds.audio_sample_rate.unwrap(), 48000);
+                        assert_eq!(esds.audio_object_type.unwrap(), 2);
                         "ES"
                     }
                     mp4::AudioCodecSpecific::FLACSpecificBox(flac) => {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -146,9 +146,7 @@ pub struct mp4parse_track_audio_info {
     pub channels: u16,
     pub bit_depth: u16,
     pub sample_rate: u32,
-    // TODO(kinetik):
-    // int32_t profile;
-    // int32_t extended_profile; // check types
+    pub profile: u16,
     pub codec_specific_config: mp4parse_byte_data,
     pub protected_data: mp4parser_sinf_info,
 }
@@ -478,6 +476,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
             }
             if let Some(channels) = v.audio_channel_count {
                 (*info).channels = channels;
+            }
+            if let Some(profile) = v.audio_object_type {
+                (*info).profile = profile;
             }
         }
         AudioCodecSpecific::FLACSpecificBox(ref flac) => {


### PR DESCRIPTION
For http://searchfox.org/mozilla-central/rev/594937fec2e2fc45fa9308ba2fb964816631f017/dom/media/MediaInfo.h#388

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1323390