### PR TITLE
Initialize the structures from native code.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -208,6 +208,7 @@ pub enum SampleEntry {
 #[derive(Debug, Clone, Default)]
 pub struct ES_Descriptor {
     pub audio_codec: CodecType,
+    pub audio_object_type: Option<u16>,
     pub audio_sample_rate: Option<u32>,
     pub audio_channel_count: Option<u16>,
     pub codec_esds: Vec<u8>,
@@ -1248,6 +1249,8 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 
     let audio_specific_config = be_u16(des)?;
 
+    let audio_object_type = audio_specific_config >> 11;
+
     let sample_index = (audio_specific_config & 0x07FF) >> 7;
 
     let channel_counts = (audio_specific_config & 0x007F) >> 3;
@@ -1255,6 +1258,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     let sample_frequency =
         frequency_table.iter().find(|item| item.0 == sample_index).map(|x| x.1);
 
+    esds.audio_object_type = Some(audio_object_type);
     esds.audio_sample_rate = sample_frequency;
     esds.audio_channel_count = Some(channel_counts);
 

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -77,6 +77,7 @@ fn public_api() {
                     mp4::AudioCodecSpecific::ES_Descriptor(esds) => {
                         assert_eq!(esds.audio_codec, mp4::CodecType::AAC);
                         assert_eq!(esds.audio_sample_rate.unwrap(), 48000);
+                        assert_eq!(esds.audio_object_type.unwrap(), 2);
                         "ES"
                     }
                     mp4::AudioCodecSpecific::FLACSpecificBox(flac) => {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -146,9 +146,7 @@ pub struct mp4parse_track_audio_info {
     pub channels: u16,
     pub bit_depth: u16,
     pub sample_rate: u32,
-    // TODO(kinetik):
-    // int32_t profile;
-    // int32_t extended_profile; // check types
+    pub profile: u16,
     pub codec_specific_config: mp4parse_byte_data,
     pub protected_data: mp4parser_sinf_info,
 }
@@ -478,6 +476,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
             }
             if let Some(channels) = v.audio_channel_count {
                 (*info).channels = channels;
+            }
+            if let Some(profile) = v.audio_object_type {
+                (*info).profile = profile;
             }
         }
         AudioCodecSpecific::FLACSpecificBox(ref flac) => {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -82,6 +82,10 @@ pub enum mp4parse_track_type {
     MP4PARSE_TRACK_TYPE_AUDIO = 1,
 }
 
+impl Default for mp4parse_track_type {
+    fn default() -> Self { mp4parse_track_type::MP4PARSE_TRACK_TYPE_VIDEO }
+}
+
 #[repr(C)]
 #[derive(PartialEq, Debug)]
 pub enum mp4parse_codec {
@@ -94,7 +98,12 @@ pub enum mp4parse_codec {
     MP4PARSE_CODEC_MP3,
 }
 
+impl Default for mp4parse_codec {
+    fn default() -> Self { mp4parse_codec::MP4PARSE_CODEC_UNKNOWN }
+}
+
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_info {
     pub track_type: mp4parse_track_type,
     pub codec: mp4parse_codec,
@@ -140,8 +149,8 @@ pub struct mp4parser_sinf_info {
     pub kid: mp4parse_byte_data,
 }
 
-#[derive(Default)]
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_audio_info {
     pub channels: u16,
     pub bit_depth: u16,
@@ -152,6 +161,7 @@ pub struct mp4parse_track_audio_info {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_video_info {
     pub display_width: u32,
     pub display_height: u32,
@@ -162,6 +172,7 @@ pub struct mp4parse_track_video_info {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_fragment_info {
     pub fragment_duration: u64,
     // TODO:
@@ -354,6 +365,9 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context_mut();
     let track_index: usize = track_index as usize;
     let info: &mut mp4parse_track_info = &mut *info;
@@ -436,6 +450,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
     if parser.is_null() || info.is_null() || (*parser).poisoned() {
         return MP4PARSE_ERROR_BADARG;
     }
+
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
 
     let context = (*parser).context_mut();
 
@@ -535,6 +552,9 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context_mut();
 
     if track_index as usize >= context.tracks.len() {
@@ -595,6 +615,9 @@ pub unsafe extern fn mp4parse_get_fragment_info(parser: *mut mp4parse_parser, in
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context();
     let info: &mut mp4parse_fragment_info = &mut *info;
 
@@ -652,6 +675,9 @@ pub unsafe extern fn mp4parse_get_pssh_info(parser: *mut mp4parse_parser, info: 
     if parser.is_null() || info.is_null() || (*parser).poisoned() {
         return MP4PARSE_ERROR_BADARG;
     }
+
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
 
     let context = (*parser).context_mut();
     let pssh_data = (*parser).pssh_data_mut();


### PR DESCRIPTION
Normally, it is not a problem in pure Rust environment; however, this library acts as the bridge between gecko and rust, so we need to initialize structures from gecko.