### PR TITLE
Initialize structures

### DIFF
--- a/mp4parse_capi/examples/test.cc
+++ b/mp4parse_capi/examples/test.cc
@@ -48,13 +48,6 @@ void test_new_parser()
   assert(dummy_value == 42);
 }
 
-template<typename T>
-void assert_zero(T *t) {
-  T zero;
-  memset(&zero, 0, sizeof(zero));
-  assert(memcmp(t, &zero, sizeof(zero)) == 0);
-}
-
 void test_arg_validation()
 {
   mp4parse_parser *parser = mp4parse_new(nullptr);
@@ -77,22 +70,16 @@ void test_arg_validation()
   assert(rv == MP4PARSE_ERROR_BADARG);
 
   mp4parse_track_info info;
-  memset(&info, 0, sizeof(info));
   rv = mp4parse_get_track_info(nullptr, 0, &info);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&info);
 
   mp4parse_track_video_info video;
-  memset(&video, 0, sizeof(video));
   rv = mp4parse_get_track_video_info(nullptr, 0, &video);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&video);
 
   mp4parse_track_audio_info audio;
-  memset(&audio, 0, sizeof(audio));
   rv = mp4parse_get_track_audio_info(nullptr, 0, &audio);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&audio);
 
   assert(dummy_value == 42);
 }
@@ -137,7 +124,6 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(tracks == 2);
 
   mp4parse_track_info info;
-  memset(&info, 0, sizeof(info));
   rv = mp4parse_get_track_info(parser, 0, &info);
   assert(rv == MP4PARSE_OK);
   assert(info.track_type == MP4PARSE_TRACK_TYPE_VIDEO);
@@ -145,7 +131,6 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(info.duration == 40000);
   assert(info.media_time == 0);
 
-  memset(&info, 0, sizeof(info));
   rv = mp4parse_get_track_info(parser, 1, &info);
   assert(rv == MP4PARSE_OK);
   assert(info.track_type == MP4PARSE_TRACK_TYPE_AUDIO);
@@ -154,7 +139,6 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(info.media_time == 21333);
 
   mp4parse_track_video_info video;
-  memset(&video, 0, sizeof(video));
   rv = mp4parse_get_track_video_info(parser, 0, &video);
   assert(rv == MP4PARSE_OK);
   assert(video.display_width == 320);
@@ -163,7 +147,6 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(video.image_height == 240);
 
   mp4parse_track_audio_info audio;
-  memset(&audio, 0, sizeof(audio));
   rv = mp4parse_get_track_audio_info(parser, 1, &audio);
   assert(rv == MP4PARSE_OK);
   assert(audio.channels == 1);
@@ -171,19 +154,13 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(audio.sample_rate == 48000);
 
   // Test with an invalid track number.
-  memset(&info, 0, sizeof(info));
-  memset(&video, 0, sizeof(video));
-  memset(&audio, 0, sizeof(audio));
 
   rv = mp4parse_get_track_info(parser, 3, &info);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&info);
   rv = mp4parse_get_track_video_info(parser, 3, &video);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&video);
   rv = mp4parse_get_track_audio_info(parser, 3, &audio);
   assert(rv == MP4PARSE_ERROR_BADARG);
-  assert_zero(&audio);
 
   mp4parse_free(parser);
   fclose(f);

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -365,7 +365,7 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
         return MP4PARSE_ERROR_BADARG;
     }
 
-    // Set default value due to it is allocated in gecko.
+    // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
     let context = (*parser).context_mut();
@@ -451,7 +451,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
         return MP4PARSE_ERROR_BADARG;
     }
 
-    // Set default value due to it is allocated in gecko.
+    // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
     let context = (*parser).context_mut();
@@ -552,7 +552,7 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
         return MP4PARSE_ERROR_BADARG;
     }
 
-    // Set default value due to it is allocated in gecko.
+    // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
     let context = (*parser).context_mut();
@@ -615,7 +615,7 @@ pub unsafe extern fn mp4parse_get_fragment_info(parser: *mut mp4parse_parser, in
         return MP4PARSE_ERROR_BADARG;
     }
 
-    // Set default value due to it is allocated in gecko.
+    // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
     let context = (*parser).context();
@@ -676,7 +676,7 @@ pub unsafe extern fn mp4parse_get_pssh_info(parser: *mut mp4parse_parser, info: 
         return MP4PARSE_ERROR_BADARG;
     }
 
-    // Set default value due to it is allocated in gecko.
+    // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
     let context = (*parser).context_mut();

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -82,6 +82,10 @@ pub enum mp4parse_track_type {
     MP4PARSE_TRACK_TYPE_AUDIO = 1,
 }
 
+impl Default for mp4parse_track_type {
+    fn default() -> Self { mp4parse_track_type::MP4PARSE_TRACK_TYPE_VIDEO }
+}
+
 #[repr(C)]
 #[derive(PartialEq, Debug)]
 pub enum mp4parse_codec {
@@ -94,7 +98,12 @@ pub enum mp4parse_codec {
     MP4PARSE_CODEC_MP3,
 }
 
+impl Default for mp4parse_codec {
+    fn default() -> Self { mp4parse_codec::MP4PARSE_CODEC_UNKNOWN }
+}
+
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_info {
     pub track_type: mp4parse_track_type,
     pub codec: mp4parse_codec,
@@ -140,8 +149,8 @@ pub struct mp4parser_sinf_info {
     pub kid: mp4parse_byte_data,
 }
 
-#[derive(Default)]
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_audio_info {
     pub channels: u16,
     pub bit_depth: u16,
@@ -152,6 +161,7 @@ pub struct mp4parse_track_audio_info {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_track_video_info {
     pub display_width: u32,
     pub display_height: u32,
@@ -162,6 +172,7 @@ pub struct mp4parse_track_video_info {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct mp4parse_fragment_info {
     pub fragment_duration: u64,
     // TODO:
@@ -354,6 +365,9 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context_mut();
     let track_index: usize = track_index as usize;
     let info: &mut mp4parse_track_info = &mut *info;
@@ -436,6 +450,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
     if parser.is_null() || info.is_null() || (*parser).poisoned() {
         return MP4PARSE_ERROR_BADARG;
     }
+
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
 
     let context = (*parser).context_mut();
 
@@ -535,6 +552,9 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context_mut();
 
     if track_index as usize >= context.tracks.len() {
@@ -595,6 +615,9 @@ pub unsafe extern fn mp4parse_get_fragment_info(parser: *mut mp4parse_parser, in
         return MP4PARSE_ERROR_BADARG;
     }
 
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
+
     let context = (*parser).context();
     let info: &mut mp4parse_fragment_info = &mut *info;
 
@@ -652,6 +675,9 @@ pub unsafe extern fn mp4parse_get_pssh_info(parser: *mut mp4parse_parser, info: 
     if parser.is_null() || info.is_null() || (*parser).poisoned() {
         return MP4PARSE_ERROR_BADARG;
     }
+
+    // Set default value due to it is allocated in gecko.
+    *info = Default::default();
 
     let context = (*parser).context_mut();
     let pssh_data = (*parser).pssh_data_mut();


### PR DESCRIPTION
mp4parser_capi acts as the bridge between rust and gecko. So the structures from gecko need to be initialized to default value in case of unused members.