### PR TITLE
Refactor read_ds_descriptor() with bitreader

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -23,6 +23,7 @@ byteorder = "0.5.0"
 afl = { version = "0.1.1", optional = true }
 afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
+bitreader = { version = "0.1.0" }
 
 [dev-dependencies]
 test-assembler = "0.1.2"


### PR DESCRIPTION
1. use bit-reader to rewrite read_ds_descriptor() for better bit reading.
2. check extended field.