### PR TITLE
parse program_config_element for channel counts

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "0.5.0"
 afl = { version = "0.1.1", optional = true }
 afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
-bitreader = { version = "0.1.0" }
+bitreader = { version = "0.2.0" }
 
 [dev-dependencies]
 test-assembler = "0.1.2"


### PR DESCRIPTION
This is from [1]. The audio channel count is zero in decoder config descriptor, so we need to calculate the channel count from program_config_element [2].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1328221
[2] 14496-3  4.4.1 Decoder configuration (GASpecificConfig)