### PR TITLE
Add travis badge link for crates.io.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -19,6 +19,9 @@ exclude = [
   "*.mp4",
 ]
 
+[badges]
+travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
+
 [dependencies]
 byteorder = "1.0.0"
 afl = { version = "0.1.1", optional = true }

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -20,6 +20,9 @@ exclude = [
 
 build = "build.rs"
 
+[badges]
+travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
+
 [dependencies]
 byteorder = "1.0.0"
 "mp4parse" = {version = "0.6.0", path = "../mp4parse"}


### PR DESCRIPTION
The package repository now has support for continuous integration
status badges. Add links for these.