### PR TITLE
Handle trailing bytes in "null-terminated" strings when reading hdlr

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1902,16 +1902,18 @@ fn read_buf<T: ReadBytesExt>(src: &mut T, size: usize) -> Result<Vec<u8>> {
 // - zero or more byte strings, with a single null terminating the string.
 // - zero byte strings with no null terminator (i.e. zero space in the box for the string)
 // - length-prefixed strings with no null terminator (e.g. bear_rotate_0.mp4)
+// - multiple byte strings where more than one byte is a null.
 fn read_null_terminated_string<T: ReadBytesExt>(src: &mut T, mut size: usize) -> Result<String> {
     let mut buf = Vec::new();
     while size > 0 {
         let c = src.read_u8()?;
+        size -= 1;
         if c == 0 {
             break;
         }
         buf.push(c);
-        size -= 1;
     }
+    skip(src, size)?;
     String::from_utf8(buf).map_err(From::from)
 }
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -884,3 +884,19 @@ fn read_esds() {
     assert_eq!(es.audio_channel_count, Some(6));
     assert_eq!(es.codec_esds, aac_esds);
 }
+
+#[test]
+fn read_null_terminated_string() {
+    let tests = vec![
+        vec![0u8],                         // Short null-terminated string.
+        vec![65u8, 0u8],                   // Normal null-terminated string.
+        vec![],                            // Empty string (no data).
+        vec![4u8, 65u8, 66u8, 67u8, 68u8], // Length-prefixed string, not null-terminated.
+        vec![0u8, 0u8],                    // Doubly null-terminated string.
+    ];
+    for v in tests.iter() {
+        let mut c = Cursor::new(v);
+        super::read_null_terminated_string(&mut c, v.len()).expect("string read failed");
+        assert_eq!(c.position(), v.len() as u64);
+    }
+}


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1339192