### PR TITLE
Follow-up to PR #65: add a missing track.codec_type init and add a test

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1764,6 +1764,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
     // Skip chan/etc. for now.
     let mut codec_specific = None;
     if name == BoxType::MP3AudioSampleEntry {
+        track.codec_type = CodecType::MP3;
         codec_specific = Some(AudioCodecSpecific::MP3);
     }
     let mut protection_info = Vec::new();

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1624,9 +1624,9 @@ fn read_hdlr<T: Read>(src: &mut BMFFBox<T>) -> Result<HandlerBox> {
 }
 
 /// Parse an video description inside an stsd box.
-fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleEntry> {
+fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, SampleEntry)> {
     let name = src.get_header().name;
-    track.codec_type = match name {
+    let codec_type = match name {
         BoxType::AVCSampleEntry | BoxType::AVC3SampleEntry => CodecType::H264,
         BoxType::VP8SampleEntry => CodecType::VP8,
         BoxType::VP9SampleEntry => CodecType::VP9,
@@ -1699,13 +1699,13 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
     }
 
     codec_specific
-        .map(|codec_specific| SampleEntry::Video(VideoSampleEntry {
+        .map(|codec_specific| (codec_type, SampleEntry::Video(VideoSampleEntry {
             data_reference_index: data_reference_index,
             width: width,
             height: height,
             codec_specific: codec_specific,
             protection_info: protection_info,
-        }))
+        })))
         .ok_or_else(|| Error::InvalidData("malformed video sample entry"))
 }
 
@@ -1726,7 +1726,7 @@ fn read_qt_wave_atom<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
 }
 
 /// Parse an audio description inside an stsd box.
-fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleEntry> {
+fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, SampleEntry)> {
     let name = src.get_header().name;
 
     // Skip uninteresting fields.
@@ -1762,9 +1762,10 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
     }
 
     // Skip chan/etc. for now.
+    let mut codec_type = CodecType::Unknown;
     let mut codec_specific = None;
     if name == BoxType::MP3AudioSampleEntry {
-        track.codec_type = CodecType::MP3;
+        codec_type = CodecType::MP3;
         codec_specific = Some(AudioCodecSpecific::MP3);
     }
     let mut protection_info = Vec::new();
@@ -1779,7 +1780,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                 }
 
                 let esds = read_esds(&mut b)?;
-                track.codec_type = esds.audio_codec;
+                codec_type = esds.audio_codec;
                 codec_specific = Some(AudioCodecSpecific::ES_Descriptor(esds));
             }
             BoxType::FLACSpecificBox => {
@@ -1788,7 +1789,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                     return Err(Error::InvalidData("malformed audio sample entry"));
                 }
                 let dfla = read_dfla(&mut b)?;
-                track.codec_type = CodecType::FLAC;
+                codec_type = CodecType::FLAC;
                 codec_specific = Some(AudioCodecSpecific::FLACSpecificBox(dfla));
             }
             BoxType::OpusSpecificBox => {
@@ -1797,12 +1798,12 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                     return Err(Error::InvalidData("malformed audio sample entry"));
                 }
                 let dops = read_dops(&mut b)?;
-                track.codec_type = CodecType::Opus;
+                codec_type = CodecType::Opus;
                 codec_specific = Some(AudioCodecSpecific::OpusSpecificBox(dops));
             }
             BoxType::QTWaveAtom => {
                 let qt_esds = read_qt_wave_atom(&mut b)?;
-                track.codec_type = qt_esds.audio_codec;
+                codec_type = qt_esds.audio_codec;
                 codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
             }
             BoxType::ProtectionSchemeInformationBox => {
@@ -1811,7 +1812,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
                 }
                 let sinf = read_sinf(&mut b)?;
                 log!("{:?} (sinf)", sinf);
-                track.codec_type = CodecType::EncryptedAudio;
+                codec_type = CodecType::EncryptedAudio;
                 protection_info.push(sinf);
             }
             _ => skip_box_content(&mut b)?,
@@ -1820,14 +1821,14 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> 
     }
 
     codec_specific
-        .map(|codec_specific| SampleEntry::Audio(AudioSampleEntry {
+        .map(|codec_specific| (codec_type, SampleEntry::Audio(AudioSampleEntry {
             data_reference_index: data_reference_index,
             channelcount: channelcount,
             samplesize: samplesize,
             samplerate: samplerate,
             codec_specific: codec_specific,
             protection_info: protection_info,
-        }))
+        })))
         .ok_or_else(|| Error::InvalidData("malformed audio sample entry"))
 }
 
@@ -1843,12 +1844,15 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleD
         let mut iter = src.box_iter();
         while let Some(mut b) = iter.next_box()? {
             let description = match track.track_type {
-                TrackType::Video => read_video_sample_entry(&mut b, track),
-                TrackType::Audio => read_audio_sample_entry(&mut b, track),
+                TrackType::Video => read_video_sample_entry(&mut b),
+                TrackType::Audio => read_audio_sample_entry(&mut b),
                 TrackType::Unknown => Err(Error::Unsupported("unknown track type")),
             };
             let description = match description {
-                Ok(desc) => desc,
+                Ok((codec_type, desc)) => {
+                    track.codec_type = codec_type;
+                    desc
+                }
                 Err(Error::Unsupported(_)) => {
                     // read_{audio,video}_desc may have returned Unsupported
                     // after partially reading the box content, so we can't

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -470,9 +470,8 @@ fn read_flac() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    let r = super::read_audio_sample_entry(&mut stream, &mut track);
-    r.unwrap();
+    let r = super::read_audio_sample_entry(&mut stream);
+    assert!(r.is_ok());
 }
 
 #[derive(Clone, Copy)]
@@ -554,8 +553,7 @@ fn read_opus() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    let r = super::read_audio_sample_entry(&mut stream, &mut track);
+    let r = super::read_audio_sample_entry(&mut stream);
     assert!(r.is_ok());
 }
 
@@ -642,8 +640,7 @@ fn avcc_limit() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    match super::read_video_sample_entry(&mut stream, &mut track) {
+    match super::read_video_sample_entry(&mut stream) {
         Err(Error::InvalidData(s)) => assert_eq!(s, "avcC box exceeds BUF_SIZE_LIMIT"),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -668,8 +665,7 @@ fn esds_limit() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    match super::read_audio_sample_entry(&mut stream, &mut track) {
+    match super::read_audio_sample_entry(&mut stream) {
         Err(Error::InvalidData(s)) => assert_eq!(s, "esds box exceeds BUF_SIZE_LIMIT"),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -694,8 +690,7 @@ fn esds_limit_2() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    match super::read_audio_sample_entry(&mut stream, &mut track) {
+    match super::read_audio_sample_entry(&mut stream) {
         Err(Error::UnexpectedEOF) => (),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -853,10 +848,9 @@ fn read_qt_wave_atom() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    super::read_audio_sample_entry(&mut stream, &mut track)
+    let (codec_type, _) = super::read_audio_sample_entry(&mut stream)
           .expect("fail to read qt wave atom");
-    assert_eq!(track.codec_type, super::CodecType::MP3);
+    assert_eq!(codec_type, super::CodecType::MP3);
 }
 
 #[test]
@@ -916,8 +910,7 @@ fn read_f4v_stsd() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut track = super::Track::new(0);
-    super::read_audio_sample_entry(&mut stream, &mut track)
+    let (codec_type, _) = super::read_audio_sample_entry(&mut stream)
           .expect("failed to read f4v stsd atom");
-    assert_eq!(track.codec_type, super::CodecType::MP3);
+    assert_eq!(codec_type, super::CodecType::MP3);
 }


### PR DESCRIPTION
This also refactors read_{audio,video}_sample_entry.