### PR TITLE
Verify we're compiled with runtime overflow checking.

### DIFF
--- a/mp4parse/tests/overflow.rs
+++ b/mp4parse/tests/overflow.rs
@@ -1,0 +1,15 @@
+/// Verify we're built with run-time integer overflow detection.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#[test]
+#[should_panic(expected = "attempt to add with overflow")]
+fn overflow_protection() {
+    let edge = u32::max_value();
+    assert_eq!(0u32, edge + 1);
+
+    let edge = u64::max_value();
+    assert_eq!(064, edge + 1);
+}


### PR DESCRIPTION
The library assumes runtime checking of integer arithmetic
overflows, which was much nicer than putting checked_foo()
methods everywhere. We set debug-assertions = true in
Cargo.toml to enable this even for release builds, where
the compiler normally turns it off for performance reasons.

However, it's not clear this is working with rust 1.15.1.
Add a test which checks for the expected panic.