### PR TITLE
Update bitreader to 0.3.0.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -27,7 +27,7 @@ byteorder = "1.0.0"
 afl = { version = "0.1.1", optional = true }
 afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
-bitreader = { version = "0.2.0" }
+bitreader = { version = "0.3.0" }
 
 [dev-dependencies]
 test-assembler = "0.1.2"


### PR DESCRIPTION
This pulls in the dual MIT license for consistency with servo code.