### PR TITLE
Fix some clippy warnings

### DIFF
--- a/mp4parse/tests/overflow.rs
+++ b/mp4parse/tests/overflow.rs
@@ -11,5 +11,5 @@ fn overflow_protection() {
     assert_eq!(0u32, edge + 1);
 
     let edge = u64::max_value();
-    assert_eq!(064, edge + 1);
+    assert_eq!(0u64, edge + 1);
 }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -126,8 +126,8 @@ fn public_audio_tenc() {
                         assert_eq!(p.code_name, "mp4a");
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);
-                            assert!(tenc.iv_size ==  16);
-                            assert!(tenc.kid == kid);
+                            assert_eq!(tenc.iv_size, 16);
+                            assert_eq!(tenc.kid, kid);
                         } else {
                             assert!(false, "Invalid test condition");
                         }
@@ -179,8 +179,8 @@ fn public_video_cenc() {
                         assert_eq!(p.code_name, "avc1");
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);
-                            assert!(tenc.iv_size ==  16);
-                            assert!(tenc.kid == kid);
+                            assert_eq!(tenc.iv_size, 16);
+                            assert_eq!(tenc.kid, kid);
                         } else {
                             assert!(false, "Invalid test condition");
                         }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -122,7 +122,7 @@ fn public_audio_tenc() {
         match track.data {
             Some(mp4::SampleEntry::Audio(a)) => {
                 match a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-                    Some(ref p) => {
+                    Some(p) => {
                         assert_eq!(p.code_name, "mp4a");
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);
@@ -175,7 +175,7 @@ fn public_video_cenc() {
         match track.data {
             Some(mp4::SampleEntry::Video(v)) => {
                 match v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-                    Some(ref p) => {
+                    Some(p) => {
                         assert_eq!(p.code_name, "avc1");
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -147,11 +147,11 @@ impl Default for mp4parse_byte_data {
 }
 
 impl mp4parse_byte_data {
-    fn set_data(&mut self, data: &Vec<u8>) {
+    fn set_data(&mut self, data: &[u8]) {
         self.length = data.len() as u32;
         self.data = data.as_ptr();
     }
-    fn set_indices(&mut self, data: &Vec<mp4parse_indice>) {
+    fn set_indices(&mut self, data: &[mp4parse_indice]) {
         self.length = data.len() as u32;
         self.indices = data.as_ptr();
     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -570,7 +570,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
     }
 
     match audio.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-        Some(ref p) => {
+        Some(p) => {
             if let Some(ref tenc) = p.tenc {
                 (*info).protected_data.is_encrypted = tenc.is_encrypted;
                 (*info).protected_data.iv_size = tenc.iv_size;
@@ -633,7 +633,7 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut mp4parse_parser,
     }
 
     match video.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-        Some(ref p) => {
+        Some(p) => {
             if let Some(ref tenc) = p.tenc {
                 (*info).protected_data.is_encrypted = tenc.is_encrypted;
                 (*info).protected_data.iv_size = tenc.iv_size;

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1006,7 +1006,7 @@ fn create_sample_table(track: &Track, track_offset_time: i64) -> Option<Vec<mp4p
             let current_index = sort_table[i] as usize;
             let peek_index = sort_table[i + 1] as usize;
             let next_start_composition_time = sample_table[peek_index].start_composition;
-            let ref mut sample = sample_table[current_index];
+            let sample = &mut sample_table[current_index];
             sample.end_composition = next_start_composition_time;
         }
     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -306,7 +306,7 @@ pub unsafe extern fn mp4parse_free(parser: *mut mp4parse_parser) {
     let _ = Box::from_raw(parser);
 }
 
-/// Enable mp4_parser log.
+/// Enable `mp4_parser` log.
 #[no_mangle]
 pub unsafe extern fn mp4parse_log(enable: bool) {
     mp4parse::set_debug_mode(enable);
@@ -1072,10 +1072,11 @@ pub unsafe extern fn mp4parse_is_fragmented(parser: *mut mp4parse_parser, track_
 
 /// Get 'pssh' system id and 'pssh' box content for eme playback.
 ///
-/// The data format in 'info' passing to gecko is:
-///   system_id
-///   pssh box size (in native endian)
-///   pssh box content (including header)
+/// The data format of the `info` struct passed to gecko is:
+///
+/// - system id (16 byte uuid)
+/// - pssh box size (32-bit native endian)
+/// - pssh box content (including header)
 #[no_mangle]
 pub unsafe extern fn mp4parse_get_pssh_info(parser: *mut mp4parse_parser, info: *mut mp4parse_pssh_info) -> mp4parse_error {
     if parser.is_null() || info.is_null() || (*parser).poisoned() {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -932,8 +932,8 @@ fn create_sample_table(track: &Track, track_offset_time: i64) -> Option<Vec<mp4p
     }
 
     // Mark the sync sample in sample_table according to 'stss'.
-    match &track.stss {
-        &Some(ref v) => {
+    match track.stss {
+        Some(ref v) => {
             for iter in &v.samples {
                 sample_table[(iter - 1) as usize].sync = true;
             }
@@ -941,8 +941,8 @@ fn create_sample_table(track: &Track, track_offset_time: i64) -> Option<Vec<mp4p
         _ => {}
     }
 
-    let ctts_iter = match &track.ctts {
-        &Some(ref v) => Some(v.samples.as_slice().iter()),
+    let ctts_iter = match track.ctts {
+        Some(ref v) => Some(v.samples.as_slice().iter()),
         _ => None,
     };
 

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1104,7 +1104,7 @@ pub unsafe extern fn mp4parse_get_pssh_info(parser: *mut mp4parse_parser, info: 
         pssh_data.extend_from_slice(pssh.box_content.as_slice());
     }
 
-    info.data.set_data(&pssh_data);
+    info.data.set_data(pssh_data);
 
     MP4PARSE_OK
 }


### PR DESCRIPTION
These are the simple ones. I've left the `single_match` and `needless_range_loop` issues for now.