### PR TITLE
get audio codec specific data

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1413,6 +1413,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     esds.audio_object_type = Some(audio_object_type);
     esds.audio_sample_rate = sample_frequency;
     esds.audio_channel_count = Some(channel_counts);
+    assert!(esds.decoder_specific_data.is_empty());
     esds.decoder_specific_data.extend(data.iter());
 
     Ok(())

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -238,6 +238,7 @@ pub struct ES_Descriptor {
     pub audio_sample_rate: Option<u32>,
     pub audio_channel_count: Option<u16>,
     pub codec_esds: Vec<u8>,
+    pub decoder_specific_data: Vec<u8>, // Data in DECODER_SPECIFIC_TAG
 }
 
 #[allow(non_camel_case_types)]
@@ -1412,6 +1413,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     esds.audio_object_type = Some(audio_object_type);
     esds.audio_sample_rate = sample_frequency;
     esds.audio_channel_count = Some(channel_counts);
+    esds.decoder_specific_data.extend(data.iter());
 
     Ok(())
 }

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -863,6 +863,8 @@ fn read_esds() {
             0x05, 0x88, 0x05, 0x00, 0x48, 0x21, 0x10, 0x00,
             0x56, 0xe5, 0x98, 0x06, 0x01, 0x02,
         ];
+    let aac_dc_descriptor = &aac_esds[22 .. 35];
+
     let mut stream = make_box(BoxSize::Auto, b"esds", |s| {
         s.B32(0) // reserved
          .append_bytes(aac_esds.as_slice())
@@ -877,6 +879,7 @@ fn read_esds() {
     assert_eq!(es.audio_sample_rate, Some(24000));
     assert_eq!(es.audio_channel_count, Some(6));
     assert_eq!(es.codec_esds, aac_esds);
+    assert_eq!(es.decoder_specific_data, aac_dc_descriptor);
 }
 
 #[test]

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -178,6 +178,11 @@ pub struct mp4parse_track_audio_info {
     pub bit_depth: u16,
     pub sample_rate: u32,
     pub profile: u16,
+    // TODO:
+    //  codec_specific_data is AudioInfo.mCodecSpecificConfig,
+    //  codec_specific_config is AudioInfo.mExtraData.
+    //  It'd be better to change name same as AudioInfo.
+    pub codec_specific_data: mp4parse_byte_data,
     pub codec_specific_config: mp4parse_byte_data,
     pub protected_data: mp4parse_sinf_info,
 }
@@ -525,6 +530,8 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
             }
             (*info).codec_specific_config.length = v.codec_esds.len() as u32;
             (*info).codec_specific_config.data = v.codec_esds.as_ptr();
+            (*info).codec_specific_data.length = v.decoder_specific_data.len() as u32;
+            (*info).codec_specific_data.data = v.decoder_specific_data.as_ptr();
             if let Some(rate) = v.audio_sample_rate {
                 (*info).sample_rate = rate;
             }


### PR DESCRIPTION
In Gecko, audio codec specific data (descriptor tag 0x05 in ```esds```) is required. PlaformDecoderModule like ffmpeg needs this field to initialize decoder.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1347834