### PR TITLE
Fix UB caused by casting a Rust fn ptr to a *c_void (BMO bug #1351497)

### DIFF
--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -29,7 +29,7 @@ mp4parse = {version = "0.7.1", path = "../mp4parse"}
 num-traits = "0.1.37"
 
 [build-dependencies]
-rusty-cheddar = "0.3.2"
+rusty-cheddar = { git = "https://github.com/kinetiknz/rusty-cheddar" }
 
 [features]
 fuzz = ["mp4parse/fuzz"]

--- a/mp4parse_capi/examples/afl-capi.rs
+++ b/mp4parse_capi/examples/afl-capi.rs
@@ -22,7 +22,7 @@ fn doit() {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input).unwrap();
     let mut cursor = std::io::Cursor::new(input);
-    let io = mp4parse_io { read: vec_read, userdata: &mut cursor as *mut _ as *mut std::os::raw::c_void };
+    let io = mp4parse_io { read: Some(vec_read), userdata: &mut cursor as *mut _ as *mut std::os::raw::c_void };
     unsafe {
         let context = mp4parse_new(&io);
         let rv = mp4parse_read(context);

--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -15,7 +15,7 @@ extern fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_voi
 fn parse_fragment() {
     let mut file = std::fs::File::open("tests/bipbop_audioinit.mp4").expect("Unknown file");
     let io = mp4parse_io {
-        read: buf_read,
+        read: Some(buf_read),
         userdata: &mut file as *mut _ as *mut std::os::raw::c_void
     };
 

--- a/mp4parse_capi/tests/test_rotation.rs
+++ b/mp4parse_capi/tests/test_rotation.rs
@@ -15,7 +15,7 @@ extern fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_voi
 fn parse_rotation() {
     let mut file = std::fs::File::open("tests/video_rotation_90.mp4").expect("Unknown file");
     let io = mp4parse_io {
-        read: buf_read,
+        read: Some(buf_read),
         userdata: &mut file as *mut _ as *mut std::os::raw::c_void
     };
 

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -15,7 +15,7 @@ extern fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_voi
 fn parse_sample_table() {
     let mut file = std::fs::File::open("tests/bipbop_nonfragment_header.mp4").expect("Unknown file");
     let io = mp4parse_io {
-        read: buf_read,
+        read: Some(buf_read),
         userdata: &mut file as *mut _ as *mut std::os::raw::c_void
     };
 
@@ -100,7 +100,7 @@ fn parse_sample_table() {
 fn parse_sample_table_with_elst() {
     let mut file = std::fs::File::open("tests/short-cenc.mp4").expect("Unknown file");
     let io = mp4parse_io {
-        read: buf_read,
+        read: Some(buf_read),
         userdata: &mut file as *mut _ as *mut std::os::raw::c_void
     };
 
@@ -156,7 +156,7 @@ fn parse_sample_table_with_elst() {
 fn parse_sample_table_with_negative_ctts() {
     let mut file = std::fs::File::open("tests/white.mp4").expect("Unknown file");
     let io = mp4parse_io {
-        read: buf_read,
+        read: Some(buf_read),
         userdata: &mut file as *mut _ as *mut std::os::raw::c_void
     };
 


### PR DESCRIPTION
Use Option<extern fn()> to represent potentially-null function pointer.
    
This addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1351497, which was filed as a rustc bug in https://github.com/rust-lang/rust/issues/40913, but revealed to be undefined behaviour that happened to work with earlier compiler versions.
    
As the comment removed in this patch describes, the only reason this code existed was to work around a limitation of rusty-cheddar.

Not sure what to do about the rusty-cheddar issue.  We can patch the generated header manually (by replacing the bogus mp4parse_io member `Option read` with `intptr_t (*read)(uint8_t* buffer, uintptr_t size, void* userdata)` for now, but that's not an ideal solution.