### PR TITLE
Limit read_buf size to BUF_SIZE_LIMIT in case of overflow problem

### DIFF
--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -641,7 +641,7 @@ fn avcc_limit() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
     match super::read_video_sample_entry(&mut stream) {
-        Err(Error::InvalidData(s)) => assert_eq!(s, "avcC box exceeds BUF_SIZE_LIMIT"),
+        Err(Error::InvalidData(s)) => assert_eq!(s, "read_buf size exceeds BUF_SIZE_LIMIT"),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
     }
@@ -666,7 +666,7 @@ fn esds_limit() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
     match super::read_audio_sample_entry(&mut stream) {
-        Err(Error::InvalidData(s)) => assert_eq!(s, "esds box exceeds BUF_SIZE_LIMIT"),
+        Err(Error::InvalidData(s)) => assert_eq!(s, "read_buf size exceeds BUF_SIZE_LIMIT"),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
     }


### PR DESCRIPTION
In [1], attacker overflows the buffer size to attack FF. To avoid this problem and the possible OOM, we limit the read_buf size to BUF_SIZE_LIMIT which is 1MB now.
This value sounds reasonable right now, we can change it in future if necessary.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1329126