### PR TITLE
Remove unused string reading from read_hdlr and read_video_sample_entry.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1645,8 +1645,8 @@ fn read_hdlr<T: Read>(src: &mut BMFFBox<T>) -> Result<HandlerBox> {
     // Skip uninteresting fields.
     skip(src, 12)?;
 
-    let bytes_left = src.bytes_left();
-    let _name = read_null_terminated_string(src, bytes_left)?;
+    // Skip name.
+    skip_box_remain(src)?;
 
     Ok(HandlerBox {
         handler_type: handler_type,
@@ -1676,12 +1676,7 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, 
     let height = be_u16(src)?;
 
     // Skip uninteresting fields.
-    skip(src, 14)?;
-
-    let _compressorname = read_fixed_length_pascal_string(src, 32)?;
-
-    // Skip uninteresting fields.
-    skip(src, 4)?;
+    skip(src, 50)?;
 
     // Skip clap/pasp/etc. for now.
     let mut codec_specific = None;
@@ -1996,43 +1991,6 @@ fn read_buf<T: ReadBytesExt>(src: &mut T, size: usize) -> Result<Vec<u8>> {
         return Err(Error::InvalidData("failed buffer read"));
     }
     Ok(buf)
-}
-
-// TODO(kinetik): Find a copy of ISO/IEC 14496-1 to confirm various string encodings.
-// XXX(kinetik): definition of "null-terminated" string is fuzzy, we have:
-// - zero or more byte strings, with a single null terminating the string.
-// - zero byte strings with no null terminator (i.e. zero space in the box for the string)
-// - length-prefixed strings with no null terminator (e.g. bear_rotate_0.mp4)
-// - multiple byte strings where more than one byte is a null.
-fn read_null_terminated_string<T: ReadBytesExt>(src: &mut T, mut size: usize) -> Result<String> {
-    let mut buf = Vec::new();
-    while size > 0 {
-        let c = src.read_u8()?;
-        size -= 1;
-        if c == 0 {
-            break;
-        }
-        buf.push(c);
-    }
-    skip(src, size)?;
-    String::from_utf8(buf).map_err(From::from)
-}
-
-#[allow(dead_code)]
-fn read_pascal_string<T: ReadBytesExt>(src: &mut T) -> Result<String> {
-    let len = src.read_u8()?;
-    let buf = read_buf(src, len as usize)?;
-    String::from_utf8(buf).map_err(From::from)
-}
-
-// Weird string encoding with a length prefix and a fixed sized buffer which
-// contains padding if the string doesn't fill the buffer.
-fn read_fixed_length_pascal_string<T: Read>(src: &mut T, size: usize) -> Result<String> {
-    assert!(size > 0);
-    let len = cmp::min(src.read_u8()? as usize, size - 1);
-    let buf = read_buf(src, len)?;
-    skip(src, size - 1 - buf.len())?;
-    String::from_utf8(buf).map_err(From::from)
 }
 
 fn be_i16<T: ReadBytesExt>(src: &mut T) -> Result<i16> {

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -742,18 +742,6 @@ fn read_edts_bogus() {
 }
 
 #[test]
-fn invalid_pascal_string() {
-    // String claims to be 32 bytes long (we provide 33 bytes to account for
-    // the 1 byte length prefix).
-    let pstr = "\x20xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-    let mut stream = Cursor::new(pstr);
-    // Reader wants to limit the total read length to 32 bytes, so any
-    // returned string must be no longer than 31 bytes.
-    let s = super::read_fixed_length_pascal_string(&mut stream, 32).unwrap();
-    assert_eq!(s.len(), 31);
-}
-
-#[test]
 fn skip_padding_in_boxes() {
     // Padding data could be added in the end of these boxes. Parser needs to skip
     // them instead of returning error.
@@ -880,22 +868,6 @@ fn read_esds() {
     assert_eq!(es.audio_channel_count, Some(6));
     assert_eq!(es.codec_esds, aac_esds);
     assert_eq!(es.decoder_specific_data, aac_dc_descriptor);
-}
-
-#[test]
-fn read_null_terminated_string() {
-    let tests = vec![
-        vec![0u8],                         // Short null-terminated string.
-        vec![65u8, 0u8],                   // Normal null-terminated string.
-        vec![],                            // Empty string (no data).
-        vec![4u8, 65u8, 66u8, 67u8, 68u8], // Length-prefixed string, not null-terminated.
-        vec![0u8, 0u8],                    // Doubly null-terminated string.
-    ];
-    for v in tests.iter() {
-        let mut c = Cursor::new(v);
-        super::read_null_terminated_string(&mut c, v.len()).expect("string read failed");
-        assert_eq!(c.position(), v.len() as u64);
-    }
 }
 
 #[test]


### PR DESCRIPTION
We never store the fields anywhere (and probably never will), so there's no point keeping this code around.  Also, we've had several parse failures in the past where the ambiguous specification of this string type has caused issues.