### PR TITLE
Build example/test FFI integration test via a Cargo integration test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 script:
   - (cd mp4parse && cargo test --verbose)
   - (cd mp4parse_capi && cargo test --verbose)
-  - make -C mp4parse_capi/examples check
   - (cd mp4parse_capi && cargo doc)
 
 deploy:

--- a/mp4parse_capi/tests/build_ffi_test.rs
+++ b/mp4parse_capi/tests/build_ffi_test.rs
@@ -1,0 +1,19 @@
+#[cfg(not(windows))]
+#[test]
+fn build_ffi_test() {
+    use std::process::Command;
+
+    let output = Command::new("make")
+        .arg("-C")
+        .arg("examples")
+        .arg("check")
+        .output()
+        .expect("failed to execute process");
+
+    println!("status: {}", output.status);
+    println!("--- stdout ---");
+    println!("{}", String::from_utf8_lossy(&output.stdout));
+    println!("-- stderr ---");
+    println!("{}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}


### PR DESCRIPTION
It's easy to forget to `make -C examples check` when making changes that may affect FFI integration, and it's painful to only discover breakage after pushing to GitHub and getting a response from Travis.

It'd be nicer if Cargo had a way to run external scripts so we could build and run these tests explicitly, but adding an integration test that does this is still an improvement over the current situation IMHO.

Longer term this may be addressed by https://github.com/rust-lang/cargo/issues/545.