### PR TITLE
Add JPEG atom for QT

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -137,4 +137,5 @@ box_database!(
     OriginalFormatBox                 0x66726d61, // "frma"
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
+    JPEGAtom                          0x6a706567, // "jpeg" - QT JPEG atom
 );

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -60,6 +60,9 @@ fn public_api() {
                         assert!(!mp4v.is_empty());
                         "MP4V"
                     }
+                    mp4::VideoCodecSpecific::JPEG => {
+                        "JPEG"
+                    }
                 }, "AVC");
             }
             Some(mp4::SampleEntry::Audio(a)) => {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -95,6 +95,7 @@ pub enum mp4parse_codec {
     VP9,
     MP3,
     MP4V,
+    JPEG,   // for QT JPEG atom in video track
 }
 
 impl Default for mp4parse_codec {
@@ -436,6 +437,8 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
                 mp4parse_codec::AVC,
             VideoCodecSpecific::ESDSConfig(_) =>
                 mp4parse_codec::MP4V,
+            VideoCodecSpecific::JPEG =>
+                mp4parse_codec::JPEG,
         },
         _ => mp4parse_codec::UNKNOWN,
     };


### PR DESCRIPTION
This is from https://bugzilla.mozilla.org/show_bug.cgi?id=1372838. JPEG could be the video track type in QT format. [1]

[1] https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html