### PR TITLE
support ac3, ec3 atom for quicktime format

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -137,5 +137,9 @@ box_database!(
     OriginalFormatBox                 0x66726d61, // "frma"
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
-    JPEGAtom                          0x6a706567, // "jpeg" - QT JPEG atom
+    JPEGAtom                          0x6a706567, // "jpeg" - QT JPEG
+    AC3SampleEntry                    0x61632d33, // "ac-3"
+    EC3SampleEntry                    0x65632d33, // "ec-3"
+    AC3SpecificBox                    0x64616333, // "dac3"
+    EC3SpecificBox                    0x64656333, // "dec3"
 );

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -267,6 +267,8 @@ pub enum AudioCodecSpecific {
     ES_Descriptor(ES_Descriptor),
     FLACSpecificBox(FLACSpecificBox),
     OpusSpecificBox(OpusSpecificBox),
+    AC3SpecificBox,
+    EC3SpecificBox,
     MP3,
 }
 
@@ -415,6 +417,8 @@ pub enum CodecType {
     EncryptedVideo,
     EncryptedAudio,
     JPEG,   // QT JPEG atom
+    AC3,    // Digital Audio Compression (AC-3, Enhanced AC-3) Standard, ETSI TS 102 366.
+    EC3,    // Digital Audio Compression (AC-3, Enhanced AC-3) Standard, ETSI TS 102 366.
 }
 
 impl Default for CodecType {
@@ -1864,6 +1868,26 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, 
                 log!("{:?} (sinf)", sinf);
                 codec_type = CodecType::EncryptedAudio;
                 protection_info.push(sinf);
+            }
+            BoxType::AC3SpecificBox => {
+                if name != BoxType::AC3SampleEntry {
+                    return Err(Error::InvalidData("malformed AC3 sample entry"));
+                }
+                // TODO: AC3SpecificBox needs to be parsed for detail information.
+                skip_box_remain(&mut b)?;
+                log!("(ac3)");
+                codec_type = CodecType::AC3;
+                codec_specific = Some(AudioCodecSpecific::AC3SpecificBox);
+            }
+            BoxType::EC3SpecificBox => {
+                if name != BoxType::EC3SpecificBox {
+                    return Err(Error::InvalidData("malformed EC3 sample entry"));
+                }
+                // TODO: EC3SpecificBox needs to be parsed for detail information.
+                skip_box_remain(&mut b)?;
+                log!("(ec3)");
+                codec_type = CodecType::EC3;
+                codec_specific = Some(AudioCodecSpecific::EC3SpecificBox);
             }
             _ => skip_box_content(&mut b)?,
         }

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -901,6 +901,31 @@ fn read_esds() {
 }
 
 #[test]
+fn read_ac3_sample_entry() {
+    let ac3 =
+        vec![
+            0x00, 0x00, 0x00, 0x0b, 0x64, 0x61, 0x63, 0x33, 0x10, 0x11, 0x60
+        ];
+
+    let mut stream = make_box(BoxSize::Auto, b"ac-3", |s| {
+        s.append_repeated(0, 6)
+         .B16(1)    // data_reference_count
+         .B16(0)
+         .append_repeated(0, 6)
+         .B16(2)
+         .B16(16)
+         .append_repeated(0, 4)
+         .B32(48000 << 16)
+         .append_bytes(ac3.as_slice())
+    });
+
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+    let (codec_type, _) = super::read_audio_sample_entry(&mut stream)
+          .expect("fail to read ac3 atom");
+    assert_eq!(codec_type, super::CodecType::AC3);
+}
+#[test]
 fn read_stsd_mp4v() {
     let mp4v =
         vec![

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -102,6 +102,12 @@ fn public_api() {
                     mp4::AudioCodecSpecific::MP3 => {
                         "MP3"
                     }
+                    mp4::AudioCodecSpecific::AC3SpecificBox => {
+                        "AC3"
+                    }
+                    mp4::AudioCodecSpecific::EC3SpecificBox => {
+                        "EC3"
+                    }
                 }, "ES");
                 assert!(a.samplesize > 0);
                 assert!(a.samplerate > 0);

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -96,6 +96,8 @@ pub enum mp4parse_codec {
     MP3,
     MP4V,
     JPEG,   // for QT JPEG atom in video track
+    AC3,
+    EC3,
 }
 
 impl Default for mp4parse_codec {
@@ -429,6 +431,10 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
                 mp4parse_codec::UNKNOWN,
             AudioCodecSpecific::MP3 =>
                 mp4parse_codec::MP3,
+            AudioCodecSpecific::AC3SpecificBox =>
+                mp4parse_codec::AC3,
+            AudioCodecSpecific::EC3SpecificBox =>
+                mp4parse_codec::EC3,
         },
         Some(SampleEntry::Video(ref video)) => match video.codec_specific {
             VideoCodecSpecific::VPxConfig(_) =>
@@ -567,6 +573,8 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
                 }
             }
         }
+        AudioCodecSpecific::AC3SpecificBox => (),
+        AudioCodecSpecific::EC3SpecificBox => (),
         AudioCodecSpecific::MP3 => (),
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1374194

Support AC3/EC3 audio sample entry in QT [1].

[1] https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html#//apple_ref/doc/uid/TP40000939-CH205-SW1