### PR TITLE
Add a top-level workspace Cargo.toml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ env:
     - CXX=g++-5
 
 script:
-  - (cd mp4parse && cargo test --verbose)
-  - (cd mp4parse_capi && cargo test --verbose)
-  - (cd mp4parse_capi && cargo doc)
+  - cargo test --all --verbose
+  - cargo doc --package mp4parse_capi
 
 deploy:
   provider: surge
-  project: ./mp4parse_capi/target/doc/
+  project: ./target/doc/
   domain: mp4parse-docs.surge.sh
   skip_cleanup: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+    "mp4parse",
+    "mp4parse_capi"
+]
+
+# Somewhat heavy-handed, but we want at least -Z force-overflow-checks=on.
+[profile.release]
+debug-assertions = true
+

--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -36,6 +36,3 @@ test-assembler = "0.1.2"
 [features]
 fuzz = ["afl", "afl-plugin", "abort_on_panic"]
 
-# Somewhat heavy-handed, but we want at least -Z force-overflow-checks=on.
-[profile.release]
-debug-assertions = true

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -34,6 +34,3 @@ moz-cheddar = "0.4.0"
 [features]
 fuzz = ["mp4parse/fuzz"]
 
-# Somewhat heavy-handed, but we want at least -Z force-overflow-checks=on.
-[profile.release]
-debug-assertions = true

--- a/mp4parse_capi/examples/Makefile
+++ b/mp4parse_capi/examples/Makefile
@@ -9,7 +9,7 @@ check: all
 HEADER := ../include/mp4parse.h
 CXXFLAGS = -g -Wall -std=c++11 -I$(dir $(HEADER))
 
-CRATE_DIR := ../target/debug/deps
+CRATE_DIR := ../../target/debug/deps
 
 libmp4parse.a libmp4parse.a.out : ../src/lib.rs
 	rustc -g --crate-type staticlib --crate-name mp4parse \


### PR DESCRIPTION
This makes development slightly easier (IMHO) since you can run `cargo test --all` in the top-level instead of having to run the tests in each sub-crate individually.