### PR TITLE
Check sample count to prevent OOM

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -67,6 +67,8 @@ pub enum Error {
     Io(std::io::Error),
     /// read_mp4 terminated without detecting a moov box.
     NoMoov,
+    /// Parse error caused by table size is over limitation.
+    TableTooLarge,
 }
 
 impl From<bitreader::BitReaderError> for Error {
@@ -1162,7 +1164,7 @@ fn read_stsc<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleToChunkBox> {
     let mut samples = Vec::new();
     for _ in 0..sample_count {
         let first_chunk = be_u32(src)?;
-        let samples_per_chunk = be_u32(src)?;
+        let samples_per_chunk = be_u32_with_limit(src)?;
         let sample_description_index = be_u32(src)?;
         samples.push(SampleToChunk {
             first_chunk: first_chunk,
@@ -1195,7 +1197,7 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
             // however, some buggy contents have negative value when version == 0.
             // So we always use Version1 here.
             0...1 => {
-                let count = be_u32(src)?;
+                let count = be_u32_with_limit(src)?;
                 let offset = TimeOffsetVersion::Version1(be_i32(src)?);
                 (count, offset)
             },
@@ -1243,7 +1245,7 @@ fn read_stts<T: Read>(src: &mut BMFFBox<T>) -> Result<TimeToSampleBox> {
     let sample_count = be_u32_with_limit(src)?;
     let mut samples = Vec::new();
     for _ in 0..sample_count {
-        let sample_count = be_u32(src)?;
+        let sample_count = be_u32_with_limit(src)?;
         let sample_delta = be_u32(src)?;
         samples.push(Sample {
             sample_count: sample_count,
@@ -2084,7 +2086,7 @@ fn be_u32<T: ReadBytesExt>(src: &mut T) -> Result<u32> {
 fn be_u32_with_limit<T: ReadBytesExt>(src: &mut T) -> Result<u32> {
     be_u32(src).and_then(|v| {
         if v > TABLE_SIZE_LIMIT {
-            return Err(Error::Unsupported("Over limited value"));
+            return Err(Error::TableTooLarge);
         }
         Ok(v)
     })

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -1031,7 +1031,7 @@ fn max_table_limit() {
     let mut stream = iter.next_box().unwrap().unwrap();
     let mut track = super::Track::new(0);
     match super::read_edts(&mut stream, &mut track) {
-        Err(Error::Unsupported(s)) => assert_eq!(s, "Over limited value"),
+        Err(Error::TableTooLarge) => (),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -69,6 +69,7 @@ pub enum mp4parse_status {
     UNSUPPORTED = 3,
     EOF = 4,
     IO = 5,
+    TABLE_TOO_LARGE = 6,
 }
 
 #[allow(non_camel_case_types)]
@@ -335,7 +336,8 @@ pub unsafe extern fn mp4parse_read(parser: *mut mp4parse_parser) -> mp4parse_sta
             // those to our Error::UnexpectedEOF variant.
             (*parser).set_poisoned(true);
             mp4parse_status::IO
-        }
+        },
+        Err(Error::TableTooLarge) => mp4parse_status::TABLE_TOO_LARGE,
     }
 }
 


### PR DESCRIPTION
This is from https://bugzilla.mozilla.org/show_bug.cgi?id=1380468.
We should check ```samples_per_chunk``` and ```sample_count``` in the parser and return a ```TABLE_TOO_LARGE``` error code.