### PR TITLE
Correct descriptor length algorithm

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1333,13 +1333,12 @@ fn find_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
         let tag = des.read_u8()?;
 
         let mut end = 0;
-        // Extension descriptor could be variable size from 0x80 to
-        // 0x80 0x80 0x80, the descriptor length is the byte after that,
-        // so it loops four times.
+        // MSB of extend_or_len indicates more bytes, up to 4 bytes.
         for _ in 0..4 {
             let extend_or_len = des.read_u8()?;
-            if extend_or_len < 0x80 {
-                end = extend_or_len + des.position() as u8;
+            end = (end << 7) + (extend_or_len & 0x7F);
+            if (extend_or_len & 0x80) == 0 {
+                end += des.position() as u8;
                 break;
             }
         };

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -975,6 +975,23 @@ fn read_esds_one_byte_extension_descriptor() {
 }
 
 #[test]
+fn read_esds_byte_extension_descriptor() {
+    let mut stream = make_box(BoxSize::Auto, b"esds", |s| {
+        s.B32(0) // reserved
+         .B16(0x0003)
+         .B16(0x8181)   // extension byte length 0x81
+         .append_repeated(0, 0x81)
+    });
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+
+    match super::read_esds(&mut stream) {
+        Ok(_) => (),
+        _ => panic!("fail to parse descriptor extension byte length"),
+    }
+}
+
+#[test]
 fn read_f4v_stsd() {
     let mut stream = make_box(BoxSize::Auto, b".mp3", |s| {
         s.append_repeated(0, 6)


### PR DESCRIPTION
The algorithm to count the descriptor length is incorrect before. (I should get an updated 14496-1 spec. )

[1] https://github.com/crosswalk-project/chromium-crosswalk/blob/master/media/formats/mp4/es_descriptor.cc#L14