### PR TITLE
Reduce max table length in 32bit arch for OOM problem

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -30,7 +30,12 @@ const BUF_SIZE_LIMIT: usize = 1024 * 1024;
 
 // Max table length. Calculating in worth case for one week long video, one
 // frame per table entry in 30 fps.
+#[cfg(target_pointer_width = "64")]
 const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24 * 7;
+
+// Reduce max table length if it is in 32 arch for memory problem.
+#[cfg(target_pointer_width = "32")]
+const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24;
 
 static DEBUG_MODE: std::sync::atomic::AtomicBool = std::sync::atomic::ATOMIC_BOOL_INIT;
 


### PR DESCRIPTION
This is from https://bugzilla.mozilla.org/show_bug.cgi?id=1389470. The VM space is 2G in the 32-bit environment which causes OOM when the table size is too large. The original length could use up to 800MB memory that causes OOM very easily.
So this patch reduces table size to one-day long video to avoid OOM.