### PR TITLE
An invalid descriptor causes an incorrect slice.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1337,18 +1337,18 @@ fn find_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
         let des = &mut Cursor::new(remains);
         let tag = des.read_u8()?;
 
-        let mut end = 0;
+        let mut end: u32 = 0;   // It's u8 without declaration type that is incorrect.
         // MSB of extend_or_len indicates more bytes, up to 4 bytes.
         for _ in 0..4 {
             let extend_or_len = des.read_u8()?;
-            end = (end << 7) + (extend_or_len & 0x7F);
+            end = (end << 7) + (extend_or_len & 0x7F) as u32;
             if (extend_or_len & 0x80) == 0 {
-                end += des.position() as u8;
+                end += des.position() as u32;
                 break;
             }
         };
 
-        if end as usize > remains.len() {
+        if (end as usize) > remains.len() || (end as u64) < des.position() {
             return Err(Error::InvalidData("Invalid descriptor."));
         }
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -1077,3 +1077,29 @@ fn unknown_audio_sample_entry() {
         _ => panic!("expected a different error result"),
     }
 }
+
+#[test]
+fn read_esds_invalid_descriptor() {
+    // tag 0x06, 0xff, 0x7f is incorrect.
+    let esds =
+        vec![
+                  0x03, 0x80, 0x80, 0x80, 0x22, 0x00, 0x00,
+            0x00, 0x04, 0x80, 0x80, 0x80, 0x14, 0x40, 0x01,
+            0x00, 0x04, 0x00, 0x00, 0x00, 0xfa, 0x00, 0x00,
+            0x00, 0xfa, 0x00, 0x05, 0x80, 0x80, 0x80, 0x02,
+            0xe8, 0x35, 0x06, 0xff, 0x7f, 0x00, 0x00, 0x02,
+        ];
+
+    let mut stream = make_box(BoxSize::Auto, b"esds", |s| {
+        s.B32(0) // reserved
+         .append_bytes(esds.as_slice())
+    });
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+
+    match super::read_esds(&mut stream) {
+        Err(Error::InvalidData(s)) => assert_eq!(s, "Invalid descriptor."),
+        _ => panic!("unexpected result with invalid descriptor"),
+    }
+}
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1387739

 ```0x06 0xff 0x7f```, the length of tag 0x06 is out of the remain slice boundary.