### PR TITLE
make sure sample_table length > 0 before using

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -977,7 +977,7 @@ fn create_sample_table(track: &Track, track_offset_time: i64) -> Option<Vec<mp4p
     //
     // Composition end time is not in specification. However, gecko needs it, so we need to
     // calculate to correct the composition end time.
-    if track.ctts.is_some() {
+    if sample_table.len() > 0 {
         // Create an index table refers to sample_table and sorted by start_composisiton time.
         let mut sort_table = Vec::new();
         sort_table.reserve(sample_table.len());


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1395244

```
SampleToChunkBox { samples: [
  SampleToChunk { first_chunk: 100663297, samples_per_chunk: 2, sample_description_index: 1 }, 
  SampleToChunk { first_chunk: 2, samples_per_chunk: 1, sample_description_index: 1 }] }
```

Invalid first_chunk causes an invalid range (100663297, 2) in ```stsc_iter```, so the sample_table doesn't have any item. That causes ```index out of bounds``` error in the bug.

I'll add testcase in gecko gtest.