### PR TITLE
add fallible memory allocation for vector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "mp4parse",
-    "mp4parse_capi"
+    "mp4parse_capi",
+    "fallible"
 ]
 
 # Somewhat heavy-handed, but we want at least -Z force-overflow-checks=on.

--- a/fallible/Cargo.toml
+++ b/fallible/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fallible"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "fallible"
+path = "lib.rs"
+
+[dependencies]
+smallvec = "0.4"

--- a/fallible/README
+++ b/fallible/README
@@ -1,0 +1,2 @@
+This is from https://github.com/servo/servo/tree/master/components/fallible
+with modificaion for mp4 demuxer.

--- a/fallible/lib.rs
+++ b/fallible/lib.rs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::mem;
+use std::vec::Vec;
+
+extern "C" {
+    fn realloc(ptr: *mut u8, bytes: usize) -> *mut u8;
+    fn malloc(bytes: usize) -> *mut u8;
+}
+
+pub trait FallibleVec<T> {
+    /// Append |val| to the end of |vec|.  Returns Ok(()) on success,
+    /// Err(()) if it fails, which can only be due to lack of memory.
+    fn try_push(&mut self, value: T) -> Result<(), ()>;
+
+    /// Expand the vector size. Return Ok(()) on success, Err(()) if it
+    /// fails.
+    fn try_reserve(&mut self, new_cap: usize) -> Result<(), ()>;
+}
+
+/////////////////////////////////////////////////////////////////
+// Vec
+
+impl<T> FallibleVec<T> for Vec<T> {
+    #[inline]
+    fn try_push(&mut self, val: T) -> Result<(), ()> {
+        if self.capacity() == self.len() {
+            let old_cap: usize = self.capacity();
+            let new_cap: usize
+                = if old_cap == 0 { 4 } else { old_cap.checked_mul(2).ok_or(()) ? };
+
+            try_extend_vec(self, new_cap)?;
+            debug_assert!(self.capacity() > self.len());
+        }
+        self.push(val);
+        Ok(())
+    }
+
+    #[inline]
+    fn try_reserve(&mut self, cap: usize) -> Result<(), ()> {
+        let new_cap = cap + self.capacity();
+        try_extend_vec(self, new_cap)?;
+        debug_assert!(self.capacity() == new_cap);
+        Ok(())
+    }
+}
+
+#[inline(never)]
+#[cold]
+fn try_extend_vec<T>(vec: &mut Vec<T>, new_cap: usize) -> Result<(), ()> {
+    let old_ptr = vec.as_mut_ptr();
+    let old_len = vec.len();
+
+    let old_cap: usize = vec.capacity();
+
+    if old_cap > new_cap {
+        return Ok(());
+    }
+
+    let new_size_bytes
+        = new_cap.checked_mul(mem::size_of::<T>()).ok_or(()) ? ;
+
+    let new_ptr = unsafe {
+        if old_cap == 0 {
+            malloc(new_size_bytes)
+        } else {
+            realloc(old_ptr as *mut u8, new_size_bytes)
+        }
+    };
+
+    if new_ptr.is_null() {
+        return Err(());
+    }
+
+    let new_vec = unsafe {
+        Vec::from_raw_parts(new_ptr as *mut T, old_len, new_cap)
+    };
+
+    mem::forget(mem::replace(vec, new_vec));
+    Ok(())
+}
+
+#[test]
+fn oom_test() {
+    let mut vec: Vec<char> = Vec::new();
+    match vec.try_reserve(std::usize::MAX) {
+        Ok(_) => panic!("it should be OOM"),
+        _ => (),
+    }
+}

--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -29,6 +29,7 @@ afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
 bitreader = { version = "0.3.0" }
 num-traits = "0.1.37"
+fallible = { path = "../fallible" }
 
 [dev-dependencies]
 test-assembler = "0.1.2"

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -11,12 +11,14 @@ extern crate afl;
 extern crate byteorder;
 extern crate bitreader;
 extern crate num_traits;
+extern crate fallible;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use bitreader::{BitReader, ReadInto};
 use std::io::{Read, Take};
 use std::io::Cursor;
 use std::cmp;
 use num_traits::Num;
+use fallible::FallibleVec;
 
 mod boxes;
 use boxes::{BoxType, FourCC};
@@ -30,14 +32,19 @@ const BUF_SIZE_LIMIT: usize = 1024 * 1024;
 
 // Max table length. Calculating in worth case for one week long video, one
 // frame per table entry in 30 fps.
-#[cfg(target_pointer_width = "64")]
 const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24 * 7;
 
-// Reduce max table length if it is in 32 arch for memory problem.
-#[cfg(target_pointer_width = "32")]
-const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24;
-
 static DEBUG_MODE: std::sync::atomic::AtomicBool = std::sync::atomic::ATOMIC_BOOL_INIT;
+
+static FALLIBLE_ALLOCATION: std::sync::atomic::AtomicBool = std::sync::atomic::ATOMIC_BOOL_INIT;
+
+pub fn set_fallible_allocation_mode(fallible: bool) {
+    FALLIBLE_ALLOCATION.store(fallible, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn get_fallible_allocation_mode() -> bool {
+    FALLIBLE_ALLOCATION.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 pub fn set_debug_mode(mode: bool) {
     DEBUG_MODE.store(mode, std::sync::atomic::Ordering::SeqCst);
@@ -54,6 +61,36 @@ macro_rules! log {
             println!( $( $args )* );
         }
     )
+}
+
+// TODO: vec_push() and vec_reserve() needs to be replaced when Rust supports
+// fallible memory allocation in raw_vec.
+pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
+    if get_fallible_allocation_mode() {
+        return vec.try_push(val);
+    }
+
+    vec.push(val);
+    Ok(())
+}
+
+pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), ()> {
+    if get_fallible_allocation_mode() {
+        return vec.try_reserve(size);
+    }
+
+    vec.reserve(size);
+    Ok(())
+}
+
+fn allocate_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
+    if get_fallible_allocation_mode() {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.try_reserve(size)?;
+        return Ok(buf);
+    }
+
+    Ok(vec![0; size])
 }
 
 /// Describes parser failures.
@@ -74,6 +111,8 @@ pub enum Error {
     NoMoov,
     /// Parse error caused by table size is over limitation.
     TableTooLarge,
+    /// Out of memory
+    OutOfMemory,
 }
 
 impl From<bitreader::BitReaderError> for Error {
@@ -94,6 +133,12 @@ impl From<std::io::Error> for Error {
 impl From<std::string::FromUtf8Error> for Error {
     fn from(_: std::string::FromUtf8Error) -> Error {
         Error::InvalidData("invalid utf8")
+    }
+}
+
+impl From<()> for Error {
+    fn from(_: ()) -> Error {
+        Error::OutOfMemory
     }
 }
 
@@ -689,7 +734,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: &mut MediaContext) -> Result<
             BoxType::TrackBox => {
                 let mut track = Track::new(context.tracks.len());
                 read_trak(&mut b, &mut track)?;
-                context.tracks.push(track);
+                vec_push(&mut context.tracks, track)?;
             }
             BoxType::MovieExtendsBox => {
                 let mvex = read_mvex(&mut b)?;
@@ -699,7 +744,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: &mut MediaContext) -> Result<
             BoxType::ProtectionSystemSpecificHeaderBox => {
                 let pssh = read_pssh(&mut b)?;
                 log!("{:?}", pssh);
-                context.psshs.push(pssh);
+                vec_push(&mut context.psshs, pssh)?;
             }
             _ => skip_box_content(&mut b)?,
         };
@@ -723,7 +768,7 @@ fn read_pssh<T: Read>(src: &mut BMFFBox<T>) -> Result<ProtectionSystemSpecificHe
             let count = be_u32_with_limit(pssh)?;
             for _ in 0..count {
                 let item = read_buf(pssh, 16)?;
-                kid.push(item);
+                vec_push(&mut kid, item)?;
             }
         }
 
@@ -940,7 +985,7 @@ fn read_ftyp<T: Read>(src: &mut BMFFBox<T>) -> Result<FileTypeBox> {
     let brand_count = bytes_left / 4;
     let mut brands = Vec::new();
     for _ in 0..brand_count {
-        brands.push(From::from(be_u32(src)?));
+        vec_push(&mut brands, From::from(be_u32(src)?))?;
     }
     Ok(FileTypeBox {
         major_brand: From::from(major),
@@ -1049,12 +1094,12 @@ fn read_elst<T: Read>(src: &mut BMFFBox<T>) -> Result<EditListBox> {
         };
         let media_rate_integer = be_i16(src)?;
         let media_rate_fraction = be_i16(src)?;
-        edits.push(Edit {
+        vec_push(&mut edits, Edit {
             segment_duration: segment_duration,
             media_time: media_time,
             media_rate_integer: media_rate_integer,
             media_rate_fraction: media_rate_fraction,
-        })
+        })?;
     }
 
     Ok(EditListBox {
@@ -1110,7 +1155,7 @@ fn read_stco<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
     let offset_count = be_u32_with_limit(src)?;
     let mut offsets = Vec::new();
     for _ in 0..offset_count {
-        offsets.push(be_u32(src)? as u64);
+        vec_push(&mut offsets, be_u32(src)? as u64)?;
     }
 
     // Padding could be added in some contents.
@@ -1127,7 +1172,7 @@ fn read_co64<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
     let offset_count = be_u32_with_limit(src)?;
     let mut offsets = Vec::new();
     for _ in 0..offset_count {
-        offsets.push(be_u64(src)?);
+        vec_push(&mut offsets, be_u64(src)?)?;
     }
 
     // Padding could be added in some contents.
@@ -1144,7 +1189,7 @@ fn read_stss<T: Read>(src: &mut BMFFBox<T>) -> Result<SyncSampleBox> {
     let sample_count = be_u32_with_limit(src)?;
     let mut samples = Vec::new();
     for _ in 0..sample_count {
-        samples.push(be_u32(src)?);
+        vec_push(&mut samples, be_u32(src)?)?;
     }
 
     // Padding could be added in some contents.
@@ -1164,11 +1209,11 @@ fn read_stsc<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleToChunkBox> {
         let first_chunk = be_u32(src)?;
         let samples_per_chunk = be_u32_with_limit(src)?;
         let sample_description_index = be_u32(src)?;
-        samples.push(SampleToChunk {
+        vec_push(&mut samples, SampleToChunk {
             first_chunk: first_chunk,
             samples_per_chunk: samples_per_chunk,
             sample_description_index: sample_description_index,
-        });
+        })?;
     }
 
     // Padding could be added in some contents.
@@ -1203,10 +1248,10 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
                 return Err(Error::InvalidData("unsupported version in 'ctts' box"));
             }
         };
-        offsets.push(TimeOffset {
+        vec_push(&mut offsets, TimeOffset {
             sample_count: sample_count,
             time_offset: time_offset,
-        });
+        })?;
     }
 
     skip_box_remain(src)?;
@@ -1224,7 +1269,7 @@ fn read_stsz<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleSizeBox> {
     let mut sample_sizes = Vec::new();
     if sample_size == 0 {
         for _ in 0..sample_count {
-            sample_sizes.push(be_u32(src)?);
+            vec_push(&mut sample_sizes, be_u32(src)?)?;
         }
     }
 
@@ -1245,10 +1290,10 @@ fn read_stts<T: Read>(src: &mut BMFFBox<T>) -> Result<TimeToSampleBox> {
     for _ in 0..sample_count {
         let sample_count = be_u32_with_limit(src)?;
         let sample_delta = be_u32(src)?;
-        samples.push(Sample {
+        vec_push(&mut samples, Sample {
             sample_count: sample_count,
             sample_delta: sample_delta,
-        });
+        })?;
     }
 
     // Padding could be added in some contents.
@@ -1543,7 +1588,7 @@ fn read_dfla<T: Read>(src: &mut BMFFBox<T>) -> Result<FLACSpecificBox> {
     let mut blocks = Vec::new();
     while src.bytes_left() > 0 {
         let block = read_flac_metadata(src)?;
-        blocks.push(block);
+        vec_push(&mut blocks, block)?;
     }
     // The box must have at least one meta block, and the first block
     // must be the METADATA_BLOCK_STREAMINFO
@@ -1737,7 +1782,7 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, 
                 }
                 let sinf = read_sinf(&mut b)?;
                 log!("{:?} (sinf)", sinf);
-                protection_info.push(sinf);
+                vec_push(&mut protection_info, sinf)?;
             }
             _ => {
                 log!("Unsupported video codec, box {:?} found", b.head.name);
@@ -1862,7 +1907,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<(CodecType, 
                 let sinf = read_sinf(&mut b)?;
                 log!("{:?} (sinf)", sinf);
                 codec_type = CodecType::EncryptedAudio;
-                protection_info.push(sinf);
+                vec_push(&mut protection_info, sinf)?;
             }
             _ => {
                 log!("Unsupported audio codec, box {:?} found", b.head.name);
@@ -1920,7 +1965,7 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleD
             } else {
                 log!("** don't know how to handle multiple descriptions **");
             }
-            descriptions.push(description);
+            vec_push(&mut descriptions, description)?;
             check_parser_state!(b.content);
             if descriptions.len() == description_count as usize {
                 break;
@@ -2015,12 +2060,15 @@ fn read_buf<T: ReadBytesExt>(src: &mut T, size: usize) -> Result<Vec<u8>> {
     if size > BUF_SIZE_LIMIT {
         return Err(Error::InvalidData("read_buf size exceeds BUF_SIZE_LIMIT"));
     }
-    let mut buf = vec![0; size];
-    let r = src.read(&mut buf)?;
-    if r != size {
-        return Err(Error::InvalidData("failed buffer read"));
+    if let Ok(mut buf) = allocate_read_buf(size) {
+        let r = src.read(&mut buf)?;
+        if r != size {
+          return Err(Error::InvalidData("failed buffer read"));
+        }
+        return Ok(buf);
     }
-    Ok(buf)
+
+    Err(Error::OutOfMemory)
 }
 
 fn be_i16<T: ReadBytesExt>(src: &mut T) -> Result<i16> {


### PR DESCRIPTION
Rust doesn't support fallible memory allocation which causes lots of OOM in https://bugzilla.mozilla.org/show_bug.cgi?id=1389470.

In https://bugzilla.mozilla.org/show_bug.cgi?id=1389009, it adds a crate for ```FallibleVec``` which calls the native memory allocation which doubles its capacity and returns a Result.

So in this PR, we call ```FallibleVec.try_push()``` for each mp4 table in case of OOM. Because the memory management could be different between pure rust and the gecko, so we add a function ```mp4parse_fallible_allocation()``` to enable it.

Frankly speaking, it more likes a temporary solution before Rust supports fallible allocation officially in https://github.com/rust-lang/rfcs/pull/2116.