### PR TITLE
initialize the read buffer

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -83,10 +83,11 @@ pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), 
     Ok(())
 }
 
-fn allocate_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
+fn reserve_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
     if get_fallible_allocation_mode() {
         let mut buf: Vec<u8> = Vec::new();
         buf.try_reserve(size)?;
+        unsafe { buf.set_len(size); }
         return Ok(buf);
     }
 
@@ -2060,7 +2061,7 @@ fn read_buf<T: ReadBytesExt>(src: &mut T, size: usize) -> Result<Vec<u8>> {
     if size > BUF_SIZE_LIMIT {
         return Err(Error::InvalidData("read_buf size exceeds BUF_SIZE_LIMIT"));
     }
-    if let Ok(mut buf) = allocate_read_buf(size) {
+    if let Ok(mut buf) = reserve_read_buf(size) {
         let r = src.read(&mut buf)?;
         if r != size {
           return Err(Error::InvalidData("failed buffer read"));


### PR DESCRIPTION
In https://github.com/mozilla/mp4parse-rust/pull/114, it needs to allocate memory for ```read_buf()```; however, it just extends its capacity, its length stays zero. So we need to initialize it to correct its length. Otherwise, it returns error in
```
impl Read for mp4parse_io {
    fn read(&mut self, buf: &mut [u8]) {
        ...
        let rv = self.read.unwrap()(buf.as_mut_ptr(), buf.len(), self.userdata);
        if rv >= 0 {
            Ok(rv as usize)
```