### PR TITLE
Don't (re)allocate if the new_cap is the same size as old_cap.

### DIFF
--- a/mp4parse_fallible/lib.rs
+++ b/mp4parse_fallible/lib.rs
@@ -55,7 +55,7 @@ fn try_extend_vec<T>(vec: &mut Vec<T>, new_cap: usize) -> Result<(), ()> {
 
     let old_cap: usize = vec.capacity();
 
-    if old_cap > new_cap {
+    if old_cap >= new_cap {
         return Ok(());
     }
 


### PR DESCRIPTION
This fixes a bug where try_reserve(0) would call malloc(0) then construct a Vec via from_raw_parts with the valid resulting 0-sized allocation and a capacity of 0.  Rust's implementation of Vec (specifically in RawVec::dealloc_buffer and RawVec::current_layout) assumes that a 0-capacity RawVec never allocated so avoids calling dealloc in this case.

r? @alfredoyang