### PR TITLE
Fix wrong feature usage in previous PR 

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -29,13 +29,10 @@ afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
 bitreader = { version = "0.3.0" }
 num-traits = "0.1.37"
-
-[target.'cfg(feature = "fallible_memory_allocation")'.dependencies]
-mp4parse_fallible = { git = "https://github.com/alfredoyang/mp4parse_fallible" }
+mp4parse_fallible = { git = "https://github.com/alfredoyang/mp4parse_fallible", optional = true }
 
 [dev-dependencies]
 test-assembler = "0.1.2"
 
 [features]
 fuzz = ["afl", "afl-plugin", "abort_on_panic"]
-

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -18,10 +18,10 @@ use std::io::Cursor;
 use std::cmp;
 use num_traits::Num;
 
-#[cfg(feature = "fallible_memory_allocation")]
+#[cfg(feature = "mp4parse_fallible")]
 extern crate mp4parse_fallible;
 
-#[cfg(feature = "fallible_memory_allocation")]
+#[cfg(feature = "mp4parse_fallible")]
 use mp4parse_fallible::FallibleVec;
 
 mod boxes;
@@ -60,7 +60,7 @@ macro_rules! log {
 // TODO: vec_push() and vec_reserve() needs to be replaced when Rust supports
 // fallible memory allocation in raw_vec.
 pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
-    #[cfg(feature = "fallible_memory_allocation")]
+    #[cfg(feature = "mp4parse_fallible")]
     {
         return vec.try_push(val);
     }
@@ -70,7 +70,7 @@ pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
 }
 
 pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), ()> {
-    #[cfg(feature = "fallible_memory_allocation")]
+    #[cfg(feature = "mp4parse_fallible")]
     {
         return vec.try_reserve(size);
     }
@@ -80,7 +80,7 @@ pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), 
 }
 
 fn allocate_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
-    #[cfg(feature = "fallible_memory_allocation")]
+    #[cfg(feature = "mp4parse_fallible")]
     {
         let mut buf: Vec<u8> = Vec::new();
         buf.try_reserve(size)?;

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -59,6 +59,7 @@ macro_rules! log {
 
 // TODO: vec_push() and vec_reserve() needs to be replaced when Rust supports
 // fallible memory allocation in raw_vec.
+#[allow(unreachable_code)]
 pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
     #[cfg(feature = "mp4parse_fallible")]
     {
@@ -69,6 +70,7 @@ pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
     Ok(())
 }
 
+#[allow(unreachable_code)]
 pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), ()> {
     #[cfg(feature = "mp4parse_fallible")]
     {
@@ -79,6 +81,7 @@ pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), 
     Ok(())
 }
 
+#[allow(unreachable_code)]
 fn allocate_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
     #[cfg(feature = "mp4parse_fallible")]
     {

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -25,6 +25,9 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.0.0"
+
+# To enable fallible memory allocation, add 'features = ["mp4parse_fallible"]'
+# in mp4parse brace.
 mp4parse = {version = "0.8.0", path = "../mp4parse"}
 num-traits = "0.1.37"
 


### PR DESCRIPTION
In https://github.com/mozilla/mp4parse-rust/pull/118, it's wrong to use 'feature'.
This PR also depresses the 'unreachable_code' warning when 'mp4parse_fallible' is enabled.