### PR TITLE
support audio sample entry v2

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -137,4 +137,6 @@ box_database!(
     OriginalFormatBox                 0x66726d61, // "frma"
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
+    AudioChannelLayoutAtom            0x6368616E, // "chan" - quicktime atom
+    LPCMAudioSampleEntry              0x6C70636D, // "lpcm" - quicktime atom
 );

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -1128,3 +1128,48 @@ fn read_invalid_pssh() {
         _ => panic!("unexpected result with invalid descriptor"),
     }
 }
+
+#[test]
+fn read_stsd_lpcm() {
+    // Extract from sample converted by ffmpeg.
+    // "ffmpeg -i ./gizmo-short.mp4 -acodec pcm_s16le -ar 96000 -vcodec copy -f mov gizmo-short.mov"
+    let lpcm =
+        vec![
+                              0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x10, 0xff,
+            0xfe, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x48, 0x40, 0xf7, 0x70, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x7f,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
+            0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x02, 0x00,
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x18, 0x63,
+            0x68, 0x61, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x64, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00,
+        ];
+
+    let mut stream = make_box(BoxSize::Auto, b"lpcm", |s| {
+        s.append_bytes(lpcm.as_slice())
+    });
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+
+    let (codec_type, sample_entry) = super::read_audio_sample_entry(&mut stream).unwrap();
+
+    assert_eq!(codec_type, super::CodecType::LPCM);
+
+    match sample_entry {
+        super::SampleEntry::Audio(a) => {
+            assert_eq!(a.samplerate, 96000.0);
+            assert_eq!(a.channelcount, 1);
+            match a.codec_specific {
+                super::AudioCodecSpecific::LPCM => (),
+                _ => panic!("it should be LPCM!"),
+            }
+        },
+        _ => panic!("it should be a audio sample entry!"),
+    }
+
+}
+

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -99,9 +99,12 @@ fn public_api() {
                     mp4::AudioCodecSpecific::MP3 => {
                         "MP3"
                     }
+                    mp4::AudioCodecSpecific::LPCM => {
+                        "LPCM"
+                    }
                 }, "ES");
                 assert!(a.samplesize > 0);
-                assert!(a.samplerate > 0);
+                assert!(a.samplerate > 0.0);
             }
             Some(mp4::SampleEntry::Unknown) | None => {}
         }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -432,7 +432,7 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut mp4parse_parser, track
                 mp4parse_codec::AAC,
             AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
                 mp4parse_codec::MP3,
-            AudioCodecSpecific::ES_Descriptor(_) =>
+            AudioCodecSpecific::ES_Descriptor(_) | AudioCodecSpecific::LPCM =>
                 mp4parse_codec::UNKNOWN,
             AudioCodecSpecific::MP3 =>
                 mp4parse_codec::MP3,
@@ -521,9 +521,9 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
         _ => return mp4parse_status::INVALID,
     };
 
-    (*info).channels = audio.channelcount;
+    (*info).channels = audio.channelcount as u16;
     (*info).bit_depth = audio.samplesize;
-    (*info).sample_rate = audio.samplerate >> 16; // 16.16 fixed point
+    (*info).sample_rate = audio.samplerate as u32;
 
     match audio.codec_specific {
         AudioCodecSpecific::ES_Descriptor(ref v) => {
@@ -572,7 +572,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut mp4parse_parser,
                 }
             }
         }
-        AudioCodecSpecific::MP3 => (),
+        AudioCodecSpecific::MP3 | AudioCodecSpecific::LPCM => (),
     }
 
     if let Some(p) = audio.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1393045

ffmpeg generates such kind of audio samples. Its spec is at https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html#//apple_ref/doc/uid/TP40000939-CH205-BBCGEBEH "Sound Sample Description (Version 2)".