### PR TITLE
'chan' box could exist in other audio entry.

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -137,6 +137,5 @@ box_database!(
     OriginalFormatBox                 0x66726d61, // "frma"
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
-    AudioChannelLayoutAtom            0x6368616E, // "chan" - quicktime atom
     LPCMAudioSampleEntry              0x6C70636D, // "lpcm" - quicktime atom
 );

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -848,6 +848,9 @@ fn read_qt_wave_atom() {
          .B8(0x6b)  // mp3
          .append_repeated(0, 12)
     }).into_inner();
+    let chan = make_box(BoxSize::Auto, b"chan", |s| {
+        s.append_repeated(0, 10)    // we don't care its data.
+    }).into_inner();
     let wave = make_box(BoxSize::Auto, b"wave", |s| {
         s.append_bytes(esds.as_slice())
     }).into_inner();
@@ -862,6 +865,7 @@ fn read_qt_wave_atom() {
          .B32(48000 << 16)
          .append_repeated(0, 16)
          .append_bytes(wave.as_slice())
+         .append_bytes(chan.as_slice())
     });
 
     let mut iter = super::BoxIter::new(&mut stream);
@@ -1172,4 +1176,3 @@ fn read_stsd_lpcm() {
     }
 
 }
-


### PR DESCRIPTION
In https://github.com/mozilla/mp4parse-rust/pull/124, it added 'chan' box when parsing 'lpcm' audio entry.  But 'chan' box could exist with other codec types, so we remove it from codes.

https://bugzilla.mozilla.org/show_bug.cgi?id=1415807