### PR TITLE
Fix failing build_ffi test under current nightly after rust-lang/rust#43067 landed.

### DIFF
--- a/mp4parse_capi/examples/Makefile
+++ b/mp4parse_capi/examples/Makefile
@@ -9,17 +9,33 @@ check: all
 HEADER := ../include/mp4parse.h
 CXXFLAGS = -g -Wall -std=c++11 -I$(dir $(HEADER))
 
+# Printing linker libraries by default was removed in rustc 1.23, so we need to
+# request them explicitly.
+RUSTC_MINOR_VERSION := $(shell rustc --version | cut -f2 -d.)
+RUSTC_MINOR_LT_23 := $(shell [ $(RUSTC_MINOR_VERSION) -lt 23 ] && echo true)
+
+ifeq ($(RUSTC_MINOR_LT_23), true)
+PRINT_NATIVE_STATIC_LIBS :=
+else
+PRINT_NATIVE_STATIC_LIBS := --print native-static-libs
+endif
+
 CRATE_DIR := ../../target/debug/deps
 
 libmp4parse.a libmp4parse.a.out : ../src/lib.rs
 	rustc -g --crate-type staticlib --crate-name mp4parse \
 	  --emit dep-info,link=$@ \
+	  $(PRINT_NATIVE_STATIC_LIBS) \
 	  -L $(CRATE_DIR) $< \
 	  2> libmp4parse.a.out || cat libmp4parse.a.out >&2
 
 -include mp4parse.d
 
+ifeq ($(RUSTC_MINOR_LT_23), true)
 test: RUST_LIBS = $(shell awk '/^note: library: / {print "-l"$$3}' libmp4parse.a.out)
+else
+test: RUST_LIBS = $(shell sed -n 's/^note: native-static-libs: //p' libmp4parse.a.out)
+endif
 test: test.cc libmp4parse.a $(HEADER)
 	$(CXX) $(CXXFLAGS) -c $(filter %.cc,$^)
 	$(CXX) $(CXXFLAGS) -o $@ *.o libmp4parse.a $(RUST_LIBS)

--- a/mp4parse_capi/tests/build_ffi_test.rs
+++ b/mp4parse_capi/tests/build_ffi_test.rs
@@ -6,6 +6,7 @@ fn build_ffi_test() {
     let output = Command::new("make")
         .arg("-C")
         .arg("examples")
+        .arg("clean")
         .arg("check")
         .output()
         .expect("failed to execute process");


### PR DESCRIPTION
Fix failing build_ffi test under current nightly after rust-lang/rust#43067 landed.

rustc no longer prints the list of libraries for the linker by default, they must be requested with --print native-static-libs.  To make life interesting, that flag is incompatible with the current stable rustc, so we need to handle both cases for now.

This fixes the failing CI builds such as https://travis-ci.org/mozilla/mp4parse-rust/jobs/302161109