### PR TITLE
Bump mp4parse version to 0.9.0 for release.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.0.0"
 
 # To enable fallible memory allocation, add 'features = ["mp4parse_fallible"]'
 # in mp4parse brace.
-mp4parse = {version = "0.8.0", path = "../mp4parse"}
+mp4parse = {version = "0.9.0", path = "../mp4parse"}
 num-traits = "0.1.37"
 
 [build-dependencies]


### PR DESCRIPTION
Keep the release version in sync with the capi crate, but the
minor bump is also warranted by api changes.