### PR TITLE
Refer to the published version of mp4parse_fallible.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -29,7 +29,7 @@ afl-plugin = { version = "0.1.1", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
 bitreader = { version = "0.3.0" }
 num-traits = "0.1.37"
-mp4parse_fallible = { git = "https://github.com/alfredoyang/mp4parse_fallible", optional = true }
+mp4parse_fallible = { version = "0.0.1", optional = true }
 
 [dev-dependencies]
 test-assembler = "0.1.2"


### PR DESCRIPTION
Now that this crate is available on crates.io, refer
to a stable version rather than building against a
git master branch.