### PR TITLE
Bump afl.rs integration to reflect latest changes.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -24,8 +24,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.0.0"
-afl = { version = "0.1.1", optional = true }
-afl-plugin = { version = "0.1.1", optional = true }
+afl = { version = "0.3", optional = true }
 abort_on_panic = { version = "1.0.0", optional = true }
 bitreader = { version = "0.3.0" }
 num-traits = "0.1.37"
@@ -35,4 +34,4 @@ mp4parse_fallible = { version = "0.0.1", optional = true }
 test-assembler = "0.1.2"
 
 [features]
-fuzz = ["afl", "afl-plugin", "abort_on_panic"]
+fuzz = ["afl", "abort_on_panic"]

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -3,8 +3,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#![cfg_attr(feature = "fuzz", feature(plugin))]
-#![cfg_attr(feature = "fuzz", plugin(afl_plugin))]
 #[cfg(feature = "fuzz")]
 extern crate afl;
 


### PR DESCRIPTION
https://users.rust-lang.org/t/announcing-afl-rs-0-2-bindings-for-american-fuzzy-lop/13981

afl.rs no longer requires unstable Rust and also doesn't need a compiler
plugin.