### PR TITLE
Switch to cbindgen 0.3

### DIFF
--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -30,7 +30,7 @@ mp4parse = {version = "0.9.0", path = "../mp4parse"}
 num-traits = "0.1.37"
 
 [build-dependencies]
-cbindgen = "0.1.30"
+cbindgen = "0.3.1"
 
 [features]
 fuzz = ["mp4parse/fuzz"]


### PR DESCRIPTION
This makes us depend on serde 1.0, just like everyone else in the ecosystem.