### PR TITLE
check descriptor length before parsing

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1376,7 +1376,8 @@ fn find_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 
     let mut remains = data;
 
-    while !remains.is_empty() {
+    // Descriptor length should be more than 2 bytes.
+    while remains.len() > 2 {
         let des = &mut Cursor::new(remains);
         let tag = des.read_u8()?;
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -1107,6 +1107,28 @@ fn read_esds_invalid_descriptor() {
     }
 }
 
+#[test]
+fn read_esds_redundant_descriptor() {
+    // the '2' at the end is redundant data.
+    let esds =
+        vec![  3, 25,   0, 1, 0, 4, 19, 64,
+              21,  0,   0, 0, 0, 0,  0,  0,
+               0,  1, 119, 0, 5, 2, 18, 16,
+               6,  1,   2,
+            ];
+
+    let mut stream = make_box(BoxSize::Auto, b"esds", |s| {
+        s.B32(0) // reserved
+         .append_bytes(esds.as_slice())
+    });
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+
+    match super::read_esds(&mut stream) {
+        Ok(esds) => assert_eq!(esds.audio_codec, super::CodecType::AAC),
+        _ => panic!("unexpected result with invalid descriptor"),
+    }
+}
 
 #[test]
 fn read_invalid_pssh() {


### PR DESCRIPTION
There is an extra byte at the end of ```esds```, in the original design, it runs into io error when reading data. That's an invalid descriptor frankly speaking, but it is good if we could tolerate this kind of error and keep parsing instead of returning an error.

the whole esds:
  ```[3, 25, 0, 1, 0, 4, 19, 64, 21, 0, 0, 0, 0, 0, 0, 0, 0, 1, 119, 0, 5, 2, 18, 16, 6, 1, 2]```
es descritor within esds:
  ```[4, 19, 64, 21, 0, 0, 0, 0, 0, 0, 0, 0, 1, 119, 0, 5, 2, 18, 16, 6, 1, 2]```
dc descriptor within es:
  ```[5, 2, 18, 16, 6, 1]```

The final ```2``` is redundant data.

https://bugzilla.mozilla.org/show_bug.cgi?id=1426773