### PR TITLE
Support alac (Apple lossless audio codec)

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -138,4 +138,5 @@ box_database!(
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
     LPCMAudioSampleEntry              0x6C70636D, // "lpcm" - quicktime atom
+    ALACSpecificBox                   0x616C6163, // "alac" - Also used by ALACSampleEntry
 );

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -654,6 +654,28 @@ fn serialize_opus_header() {
 }
 
 #[test]
+fn read_alac() {
+    let mut stream = make_box(BoxSize::Auto, b"alac", |s| {
+        s.append_repeated(0, 6) // reserved
+         .B16(1) // data reference index
+         .B32(0) // reserved
+         .B32(0) // reserved
+         .B16(2) // channel count
+         .B16(16) // bits per sample
+         .B16(0) // pre_defined
+         .B16(0) // reserved
+         .B32(44100 << 16) // Sample rate
+         .append_bytes(&make_fullbox(BoxSize::Auto, b"alac", 0, |s| {
+             s.append_bytes(&vec![0xfa; 24])
+         }).into_inner())
+    });
+    let mut iter = super::BoxIter::new(&mut stream);
+    let mut stream = iter.next_box().unwrap().unwrap();
+    let r = super::read_audio_sample_entry(&mut stream);
+    assert!(r.is_ok());
+}
+
+#[test]
 fn avcc_limit() {
     let mut stream = make_box(BoxSize::Auto, b"avc1", |s| {
         s.append_repeated(0, 6)

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -96,6 +96,10 @@ fn public_api() {
                         assert!(opus.version > 0);
                         "Opus"
                     }
+                    mp4::AudioCodecSpecific::ALACSpecificBox(alac) => {
+                        assert!(alac.data.len() == 24 || alac.data.len() == 48);
+                        "ALAC"
+                    }
                     mp4::AudioCodecSpecific::MP3 => {
                         "MP3"
                     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -98,6 +98,7 @@ pub enum Mp4parseCodec {
     Jpeg,   // for QT JPEG atom in video track
     Ac3,
     Ec3,
+    Alac,
 }
 
 impl Default for Mp4parseCodec {
@@ -429,6 +430,8 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut Mp4parseParser, track_
                 Mp4parseCodec::Unknown,
             AudioCodecSpecific::MP3 =>
                 Mp4parseCodec::Mp3,
+            AudioCodecSpecific::ALACSpecificBox(_) =>
+                Mp4parseCodec::Alac,
         },
         Some(SampleEntry::Video(ref video)) => match video.codec_specific {
             VideoCodecSpecific::VPxConfig(_) =>
@@ -564,6 +567,10 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut Mp4parseParser, 
                     }
                 }
             }
+        }
+        AudioCodecSpecific::ALACSpecificBox(ref alac) => {
+            (*info).extra_data.length = alac.data.len() as u32;
+            (*info).extra_data.data = alac.data.as_ptr();
         }
         AudioCodecSpecific::MP3 | AudioCodecSpecific::LPCM => (),
     }


### PR DESCRIPTION
The compatibility encoding is not supported as I can't find any files encoded that way. See the bottom of https://github.com/macosforge/alac/blob/master/ALACMagicCookieDescription.txt for a description.

Closes #57 