### PR TITLE
Move env_logger to dev-dependencies.

### DIFF
--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -23,7 +23,6 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.2.1"
-env_logger = "0.5.3"
 log = "0.4"
 
 # To enable fallible memory allocation, add 'features = ["mp4parse_fallible"]'
@@ -31,9 +30,11 @@ log = "0.4"
 mp4parse = {version = "0.10.0", path = "../mp4parse"}
 num-traits = "0.2.0"
 
+[dev-dependencies]
+env_logger = "0.5.3"
+
 [build-dependencies]
 cbindgen = "0.4.3"
 
 [features]
 fuzz = ["mp4parse/fuzz"]
-


### PR DESCRIPTION
When we switched to the `log` crate from our own custom logging
in v0.10, I added `env_logger` as an implementation so our code
examples would continue to work the same way.

However, since `env_logger` is _only_ needed for example code
is should be declared as a dev-dependency so it doesn't add
a transitive dependency to other builds using the library,
which may use a different logging implementation, or a just
a different version of `env_logger` than the one we've declared.