### PR TITLE
Parse uuid box types

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -139,4 +139,5 @@ box_database!(
     CompositionOffsetBox              0x63747473, // "ctts"
     LPCMAudioSampleEntry              0x6C70636D, // "lpcm" - quicktime atom
     ALACSpecificBox                   0x616C6163, // "alac" - Also used by ALACSampleEntry
+    UuidBox                           0x75756964, // "uuid"
 );

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -140,6 +140,8 @@ struct BoxHeader {
     size: u64,
     /// Offset to the start of the contained data (or header size).
     offset: u64,
+    /// Uuid for extended type.
+    uuid: Option<[u8; 16]>,
 }
 
 /// File type box 'ftyp'.
@@ -593,15 +595,31 @@ fn read_box_header<T: ReadBytesExt>(src: &mut T) -> Result<BoxHeader> {
         2...7 => return Err(Error::InvalidData("malformed size")),
         _ => size32 as u64,
     };
-    let offset = match size32 {
+    let mut offset = match size32 {
         1 => 4 + 4 + 8,
         _ => 4 + 4,
+    };
+    let uuid = if name == BoxType::UuidBox {
+        if size < offset + 16 {
+            return Err(Error::InvalidData("malformed size for uuid"));
+        }
+        let mut buffer = [0u8; 16];
+        let count = src.read(&mut buffer)?;
+        if count < 16 {
+            None
+        } else {
+            offset += 16;
+            Some(buffer)
+        }
+    } else {
+        None
     };
     assert!(offset <= size);
     Ok(BoxHeader {
         name: name,
         size: size,
         offset: offset,
+        uuid: uuid,
     })
 }
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -63,6 +63,17 @@ fn make_box<F>(size: BoxSize, name: &[u8; 4], func: F) -> Cursor<Vec<u8>>
     Cursor::new(section.get_contents().unwrap())
 }
 
+fn make_uuid_box<F>(size: BoxSize, uuid: &[u8; 16], func: F) -> Cursor<Vec<u8>>
+    where F: Fn(Section) -> Section
+{
+    make_box(size, b"uuid", |mut s| {
+        for b in uuid {
+            s = s.B8(*b);
+        }
+        func(s)
+    })
+}
+
 fn make_fullbox<F>(size: BoxSize, name: &[u8; 4], version: u8, func: F) -> Cursor<Vec<u8>>
     where F: Fn(Section) -> Section
 {
@@ -80,6 +91,7 @@ fn read_box_header_short() {
     let header = super::read_box_header(&mut stream).unwrap();
     assert_eq!(header.name, BoxType::UnknownBox(0x74657374)); // "test"
     assert_eq!(header.size, 8);
+    assert!(header.uuid.is_none());
 }
 
 #[test]
@@ -88,6 +100,7 @@ fn read_box_header_long() {
     let header = super::read_box_header(&mut stream).unwrap();
     assert_eq!(header.name, BoxType::UnknownBox(0x74657374)); // "test"
     assert_eq!(header.size, 16);
+    assert!(header.uuid.is_none());
 }
 
 #[test]
@@ -115,6 +128,24 @@ fn read_box_header_long_invalid_size() {
         Err(Error::InvalidData(s)) => assert_eq!(s, "malformed wide size"),
         _ => panic!("unexpected result reading box with invalid size"),
     };
+}
+
+#[test]
+fn read_box_header_uuid() {
+    const HEADER_UUID: [u8; 16] = [
+        0x85, 0xc0, 0xb6,0x87,
+        0x82, 0x0f,
+        0x11, 0xe0,
+        0x81, 0x11,
+        0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48 ];
+
+    let mut stream = make_uuid_box(BoxSize::Short(24), &HEADER_UUID, |s| s);
+    let mut iter = super::BoxIter::new(&mut stream);
+    let stream = iter.next_box().unwrap().unwrap();
+    assert_eq!(stream.head.name, BoxType::UuidBox);
+    assert_eq!(stream.head.size, 24);
+    assert!(stream.head.uuid.is_some());
+    assert_eq!(stream.head.uuid.unwrap(), HEADER_UUID);
 }
 
 #[test]


### PR DESCRIPTION
This allow parsing 'uuid' boxes.

While this is generic to the ISO Base Media format, I implemented this to be able to parse Canon CR3 files (brand 'crx ') that use 'uuid' boxes.