### PR TITLE
Misc improvements

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -436,6 +436,7 @@ impl MediaContext {
 pub enum TrackType {
     Audio,
     Video,
+    Metadata,
     Unknown,
 }
 
@@ -918,6 +919,7 @@ fn read_mdia<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
                 match hdlr.handler_type.value.as_ref() {
                     "vide" => track.track_type = TrackType::Video,
                     "soun" => track.track_type = TrackType::Audio,
+                    "meta" => track.track_type = TrackType::Metadata,
                     _ => (),
                 }
                 debug!("{:?}", hdlr);
@@ -2005,6 +2007,7 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleD
             let description = match track.track_type {
                 TrackType::Video => read_video_sample_entry(&mut b),
                 TrackType::Audio => read_audio_sample_entry(&mut b),
+                TrackType::Metadata => Err(Error::Unsupported("metadata track")),
                 TrackType::Unknown => Err(Error::Unsupported("unknown track type")),
             };
             let description = match description {

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -25,6 +25,9 @@ extern crate mp4parse_fallible;
 #[cfg(feature = "mp4parse_fallible")]
 use mp4parse_fallible::FallibleVec;
 
+#[macro_use]
+mod macros;
+
 mod boxes;
 use boxes::{BoxType, FourCC};
 
@@ -658,15 +661,6 @@ fn skip_box_remain<T: Read>(src: &mut BMFFBox<T>) -> Result<()> {
         len
     };
     skip(src, remain)
-}
-
-macro_rules! check_parser_state {
-    ( $src:expr ) => {
-        if $src.limit() > 0 {
-            debug!("bad parser state: {} content bytes left", $src.limit());
-            return Err(Error::InvalidData("unread box content or bad parser sync"));
-        }
-    }
 }
 
 /// Read the contents of a box, including sub boxes.

--- a/mp4parse/src/macros.rs
+++ b/mp4parse/src/macros.rs
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+macro_rules! check_parser_state {
+    ( $src:expr ) => {
+        if $src.limit() > 0 {
+            debug!("bad parser state: {} content bytes left", $src.limit());
+            return Err(Error::InvalidData("unread box content or bad parser sync"));
+        }
+    }
+}

--- a/mp4parse_capi/examples/afl-capi.rs
+++ b/mp4parse_capi/examples/afl-capi.rs
@@ -71,6 +71,9 @@ fn doit() {
                                          audio.channels, audio.bit_depth, audio.sample_rate);
                             }
                         }
+                        Mp4parseTrackType::Metadata => {
+                            println!("  metadata found (TODO)");
+                        }
                     }
                 }
             }

--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -101,6 +101,9 @@ fn dump_file(filename: &str) {
                         }
                     }
                 },
+                Mp4parseTrackType::Metadata => {
+                    println!("TODO metadata track");
+                },
             }
 
             let mut indices = Mp4parseByteData::default();

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -77,6 +77,7 @@ pub enum Mp4parseStatus {
 pub enum Mp4parseTrackType {
     Video = 0,
     Audio = 1,
+    Metadata = 2,
 }
 
 impl Default for Mp4parseTrackType {
@@ -406,6 +407,7 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut Mp4parseParser, track_
     info.track_type = match context.tracks[track_index].track_type {
         TrackType::Video => Mp4parseTrackType::Video,
         TrackType::Audio => Mp4parseTrackType::Audio,
+        TrackType::Metadata => Mp4parseTrackType::Metadata,
         TrackType::Unknown => return Mp4parseStatus::Unsupported,
     };
 


### PR DESCRIPTION
- Recognize metadata tracks: they can matter.

- Move check_parser_state macro to boxes.rs so that it can be used by another module.

The purpose of these is to facilitate my fork that I use to parse Canon CR3 files. These changes are generic to the IsoBaseMedia.