### PR TITLE
Enable osx and win travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ rust:
   - stable
   - nightly
 
+os:
+  - linux
+  - osx
+
+before_install:
+  # Work around https://github.com/travis-ci/travis-ci/issues/8826, when that
+  # issue is fixed we can just include gcc in the addons
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@5; fi
+  
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
 os:
   - linux
   - osx
+  - windows
 
 before_install:
   # Work around https://github.com/travis-ci/travis-ci/issues/8826, when that


### PR DESCRIPTION
Enable further operating systems on Travis to get more coverage. Since we don't run make and gcc on Windows we don't need any special installs outside of the default Rust env. OSX requires a little tweaking, but also works.

Windows support is new to Travis, but given we're not doing anything too exotic, should hopefully be safe.