### PR TITLE
 Handle and expose multiple sample descriptions per track

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -942,9 +942,13 @@ fn read_qt_wave_atom() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let (codec_type, _) = super::read_audio_sample_entry(&mut stream)
+    let sample_entry = super::read_audio_sample_entry(&mut stream)
           .expect("fail to read qt wave atom");
-    assert_eq!(codec_type, super::CodecType::MP3);
+    match sample_entry {
+        super::SampleEntry::Audio(sample_entry) =>
+          assert_eq!(sample_entry.codec_type, super::CodecType::MP3),
+        _ => assert!(false, "fail to read audio sample enctry"),
+    }
 }
 
 #[test]
@@ -1033,12 +1037,11 @@ fn read_stsd_mp4v() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let (codec_type, sample_entry) = super::read_video_sample_entry(&mut stream).unwrap();
-
-    assert_eq!(codec_type, super::CodecType::MP4V);
+    let sample_entry = super::read_video_sample_entry(&mut stream).unwrap();
 
     match sample_entry {
         super::SampleEntry::Video(v) => {
+            assert_eq!(v.codec_type, super::CodecType::MP4V);
             assert_eq!(v.width, 720);
             assert_eq!(v.height, 480);
             match v.codec_specific {
@@ -1110,9 +1113,13 @@ fn read_f4v_stsd() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let (codec_type, _) = super::read_audio_sample_entry(&mut stream)
+    let sample_entry = super::read_audio_sample_entry(&mut stream)
           .expect("failed to read f4v stsd atom");
-    assert_eq!(codec_type, super::CodecType::MP3);
+    match sample_entry {
+        super::SampleEntry::Audio(sample_entry) =>
+          assert_eq!(sample_entry.codec_type, super::CodecType::MP3),
+        _ => assert!(false, "fail to read audio sample enctry"),
+    }
 }
 
 #[test]
@@ -1152,7 +1159,7 @@ fn unknown_video_sample_entry() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
     match super::read_video_sample_entry(&mut stream) {
-        Ok((super::CodecType::Unknown, super::SampleEntry::Unknown)) => (),
+        Ok(super::SampleEntry::Unknown) => (),
         _ => panic!("expected a different error result"),
     }
 }
@@ -1177,7 +1184,7 @@ fn unknown_audio_sample_entry() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
     match super::read_audio_sample_entry(&mut stream) {
-        Ok((super::CodecType::Unknown, super::SampleEntry::Unknown)) => (),
+        Ok(super::SampleEntry::Unknown) => (),
         _ => panic!("expected a different error result"),
     }
 }
@@ -1281,12 +1288,11 @@ fn read_stsd_lpcm() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let (codec_type, sample_entry) = super::read_audio_sample_entry(&mut stream).unwrap();
-
-    assert_eq!(codec_type, super::CodecType::LPCM);
+    let sample_entry = super::read_audio_sample_entry(&mut stream).unwrap();
 
     match sample_entry {
         super::SampleEntry::Audio(a) => {
+            assert_eq!(a.codec_type, super::CodecType::LPCM);
             assert_eq!(a.samplerate, 96000.0);
             assert_eq!(a.channelcount, 1);
             match a.codec_specific {

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -14,7 +14,7 @@ static AUDIO_EME_MP4: &'static str = "tests/bipbop-cenc-audioinit.mp4";
 static VIDEO_EME_MP4: &'static str = "tests/bipbop_480wp_1001kbps-cenc-video-key1-init.mp4";
 static VIDEO_AV1_MP4: &'static str = "tests/tiny_av1.mp4";
 
-// Taken from https://github.com/GuillaumeGomez/audio-video-metadata/blob/9dff40f565af71d5502e03a2e78ae63df95cfd40/src/metadata.rs#L53
+// Adapted from https://github.com/GuillaumeGomez/audio-video-metadata/blob/9dff40f565af71d5502e03a2e78ae63df95cfd40/src/metadata.rs#L53
 #[test]
 fn public_api() {
     let mut fd = File::open(MINI_MP4).expect("Unknown file");
@@ -26,15 +26,13 @@ fn public_api() {
     mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
     assert_eq!(context.timescale, Some(mp4::MediaTimeScale(1000)));
     for track in context.tracks {
-        match track.data {
-            Some(mp4::SampleEntry::Video(v)) => {
+        match track.track_type {
+            mp4::TrackType::Video => {
                 // track part
                 assert_eq!(track.duration, Some(mp4::TrackScaledTime(512, 0)));
                 assert_eq!(track.empty_duration, Some(mp4::MediaScaledTime(0)));
                 assert_eq!(track.media_time, Some(mp4::TrackScaledTime(0, 0)));
                 assert_eq!(track.timescale, Some(mp4::TrackTimeScale(12800, 0)));
-                assert_eq!(v.width, 320);
-                assert_eq!(v.height, 240);
 
                 // track.tkhd part
                 let tkhd = track.tkhd.unwrap();
@@ -43,13 +41,20 @@ fn public_api() {
                 assert_eq!(tkhd.width, 20971520);
                 assert_eq!(tkhd.height, 15728640);
 
-                // track.data part
+                // track.stsd part
+                let stsd = track.stsd.expect("expected an stsd");
+                let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
+                    mp4::SampleEntry::Video(v) => v,
+                    _ => panic!("expected a VideoSampleEntry"),
+                };
+                assert_eq!(v.width, 320);
+                assert_eq!(v.height, 240);
                 assert_eq!(match v.codec_specific {
-                    mp4::VideoCodecSpecific::AVCConfig(v) => {
-                        assert!(!v.is_empty());
+                    mp4::VideoCodecSpecific::AVCConfig(ref avc) => {
+                        assert!(!avc.is_empty());
                         "AVC"
                     }
-                    mp4::VideoCodecSpecific::VPxConfig(vpx) => {
+                    mp4::VideoCodecSpecific::VPxConfig(ref vpx) => {
                         // We don't enter in here, we just check if fields are public.
                         assert!(vpx.bit_depth > 0);
                         assert!(vpx.color_space > 0);
@@ -57,16 +62,16 @@ fn public_api() {
                         assert!(!vpx.codec_init.is_empty());
                         "VPx"
                     }
-                    mp4::VideoCodecSpecific::ESDSConfig(mp4v) => {
+                    mp4::VideoCodecSpecific::ESDSConfig(ref mp4v) => {
                         assert!(!mp4v.is_empty());
                         "MP4V"
                     }
-                    mp4::VideoCodecSpecific::AV1Config(_av1c) => {
+                    mp4::VideoCodecSpecific::AV1Config(ref _av1c) => {
                         "AV1"
                     }
                 }, "AVC");
             }
-            Some(mp4::SampleEntry::Audio(a)) => {
+            mp4::TrackType::Audio => {
                 // track part
                 assert_eq!(track.duration, Some(mp4::TrackScaledTime(2944, 1)));
                 assert_eq!(track.empty_duration, Some(mp4::MediaScaledTime(0)));
@@ -80,27 +85,32 @@ fn public_api() {
                 assert_eq!(tkhd.width, 0);
                 assert_eq!(tkhd.height, 0);
 
-                // track.data part
+                // track.stsd part
+                let stsd = track.stsd.expect("expected an stsd");
+                let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
+                    mp4::SampleEntry::Audio(a) => a,
+                    _ => panic!("expected a AudioSampleEntry"),
+                };
                 assert_eq!(match a.codec_specific {
-                    mp4::AudioCodecSpecific::ES_Descriptor(esds) => {
+                    mp4::AudioCodecSpecific::ES_Descriptor(ref esds) => {
                         assert_eq!(esds.audio_codec, mp4::CodecType::AAC);
                         assert_eq!(esds.audio_sample_rate.unwrap(), 48000);
                         assert_eq!(esds.audio_object_type.unwrap(), 2);
                         "ES"
                     }
-                    mp4::AudioCodecSpecific::FLACSpecificBox(flac) => {
+                    mp4::AudioCodecSpecific::FLACSpecificBox(ref flac) => {
                         // STREAMINFO block must be present and first.
                         assert!(!flac.blocks.is_empty());
                         assert_eq!(flac.blocks[0].block_type, 0);
                         assert_eq!(flac.blocks[0].data.len(), 34);
                         "FLAC"
                     }
-                    mp4::AudioCodecSpecific::OpusSpecificBox(opus) => {
+                    mp4::AudioCodecSpecific::OpusSpecificBox(ref opus) => {
                         // We don't enter in here, we just check if fields are public.
                         assert!(opus.version > 0);
                         "Opus"
                     }
-                    mp4::AudioCodecSpecific::ALACSpecificBox(alac) => {
+                    mp4::AudioCodecSpecific::ALACSpecificBox(ref alac) => {
                         assert!(alac.data.len() == 24 || alac.data.len() == 48);
                         "ALAC"
                     }
@@ -114,7 +124,7 @@ fn public_api() {
                 assert!(a.samplesize > 0);
                 assert!(a.samplerate > 0.0);
             }
-            Some(mp4::SampleEntry::Unknown) | None => {}
+            mp4::TrackType::Metadata | mp4::TrackType::Unknown => {}
         }
     }
 }
@@ -133,28 +143,26 @@ fn public_audio_tenc() {
     let mut context = mp4::MediaContext::new();
     mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
     for track in context.tracks {
-        assert_eq!(track.codec_type, mp4::CodecType::EncryptedAudio);
-        match track.data {
-            Some(mp4::SampleEntry::Audio(a)) => {
-                match a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-                    Some(p) => {
-                        assert_eq!(p.code_name, "mp4a");
-                        if let Some(ref tenc) = p.tenc {
-                            assert!(tenc.is_encrypted > 0);
-                            assert_eq!(tenc.iv_size, 16);
-                            assert_eq!(tenc.kid, kid);
-                        } else {
-                            assert!(false, "Invalid test condition");
-                        }
-                    },
-                    _=> {
-                        assert!(false, "Invalid test condition");
-                    },
+        let stsd = track.stsd.expect("expected an stsd");
+        let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
+            mp4::SampleEntry::Audio(a) => a,
+            _ => panic!("expected a AudioSampleEntry"),
+        };
+        assert_eq!(a.codec_type, mp4::CodecType::EncryptedAudio);
+        match a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+            Some(ref p) => {
+                assert_eq!(p.code_name, "mp4a");
+                if let Some(ref tenc) = p.tenc {
+                    assert!(tenc.is_encrypted > 0);
+                    assert_eq!(tenc.iv_size, 16);
+                    assert_eq!(tenc.kid, kid);
+                } else {
+                    assert!(false, "Invalid test condition");
                 }
             },
-            _ => {
+            _=> {
                 assert!(false, "Invalid test condition");
-            }
+            },
         }
     }
 }
@@ -186,26 +194,24 @@ fn public_video_cenc() {
     let mut context = mp4::MediaContext::new();
     mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
     for track in context.tracks {
-        assert_eq!(track.codec_type, mp4::CodecType::EncryptedVideo);
-        match track.data {
-            Some(mp4::SampleEntry::Video(v)) => {
-                match v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-                    Some(p) => {
-                        assert_eq!(p.code_name, "avc1");
-                        if let Some(ref tenc) = p.tenc {
-                            assert!(tenc.is_encrypted > 0);
-                            assert_eq!(tenc.iv_size, 16);
-                            assert_eq!(tenc.kid, kid);
-                        } else {
-                            assert!(false, "Invalid test condition");
-                        }
-                    },
-                    _=> {
-                        assert!(false, "Invalid test condition");
-                    },
+        let stsd = track.stsd.expect("expected an stsd");
+        let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
+            mp4::SampleEntry::Video(ref v) => v,
+            _ => panic!("expected a VideoSampleEntry"),
+        };
+        assert_eq!(v.codec_type, mp4::CodecType::EncryptedVideo);
+        match v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+            Some(ref p) => {
+                assert_eq!(p.code_name, "avc1");
+                if let Some(ref tenc) = p.tenc {
+                    assert!(tenc.is_encrypted > 0);
+                    assert_eq!(tenc.iv_size, 16);
+                    assert_eq!(tenc.kid, kid);
+                } else {
+                    assert!(false, "Invalid test condition");
                 }
             },
-            _ => {
+            _=> {
                 assert!(false, "Invalid test condition");
             }
         }
@@ -223,53 +229,52 @@ fn public_video_cenc() {
 
 #[test]
 fn public_video_av1() {
-  let mut fd = File::open(VIDEO_AV1_MP4).expect("Unknown file");
-  let mut buf = Vec::new();
-  fd.read_to_end(&mut buf).expect("File error");
+    let mut fd = File::open(VIDEO_AV1_MP4).expect("Unknown file");
+    let mut buf = Vec::new();
+    fd.read_to_end(&mut buf).expect("File error");
 
-  let mut c = Cursor::new(&buf);
-  let mut context = mp4::MediaContext::new();
-  mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
-  for track in context.tracks {
-      assert_eq!(track.codec_type, mp4::CodecType::AV1);
-      match track.data {
-          Some(mp4::SampleEntry::Video(v)) => {
-              // track part
-              assert_eq!(track.duration, Some(mp4::TrackScaledTime(512, 0)));
-              assert_eq!(track.empty_duration, Some(mp4::MediaScaledTime(0)));
-              assert_eq!(track.media_time, Some(mp4::TrackScaledTime(0,0)));
-              assert_eq!(track.timescale, Some(mp4::TrackTimeScale(12288, 0)));
-              assert_eq!(v.width, 64);
-              assert_eq!(v.height, 64);
+    let mut c = Cursor::new(&buf);
+    let mut context = mp4::MediaContext::new();
+    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    for track in context.tracks {
+        // track part
+        assert_eq!(track.duration, Some(mp4::TrackScaledTime(512, 0)));
+        assert_eq!(track.empty_duration, Some(mp4::MediaScaledTime(0)));
+        assert_eq!(track.media_time, Some(mp4::TrackScaledTime(0,0)));
+        assert_eq!(track.timescale, Some(mp4::TrackTimeScale(12288, 0)));
 
-              // track.tkhd part
-              let tkhd = track.tkhd.unwrap();
-              assert_eq!(tkhd.disabled, false);
-              assert_eq!(tkhd.duration, 42);
-              assert_eq!(tkhd.width, 4194304);
-              assert_eq!(tkhd.height, 4194304);
+        // track.tkhd part
+        let tkhd = track.tkhd.unwrap();
+        assert_eq!(tkhd.disabled, false);
+        assert_eq!(tkhd.duration, 42);
+        assert_eq!(tkhd.width, 4194304);
+        assert_eq!(tkhd.height, 4194304);
 
-              match v.codec_specific {
-                  mp4::VideoCodecSpecific::AV1Config(av1c) => {
-                      // TODO: test av1c fields once ffmpeg is updated
-                      assert_eq!(av1c.profile, 0);
-                      assert_eq!(av1c.level, 0);
-                      assert_eq!(av1c.tier, 0);
-                      assert_eq!(av1c.bit_depth, 8);
-                      assert_eq!(av1c.monochrome, false);
-                      assert_eq!(av1c.chroma_subsampling_x, 1);
-                      assert_eq!(av1c.chroma_subsampling_y, 1);
-                      assert_eq!(av1c.chroma_sample_position, 0);
-                      assert_eq!(av1c.initial_presentation_delay_present, false);
-                      assert_eq!(av1c.initial_presentation_delay_minus_one, 0);
-                  },
-                  _ => assert!(false, "Invalid test condition"),
-              }
+        // track.stsd part
+        let stsd = track.stsd.expect("expected an stsd");
+        let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
+            mp4::SampleEntry::Video(ref v) => v,
+            _ => panic!("expected a VideoSampleEntry"),
+        };
+        assert_eq!(v.codec_type, mp4::CodecType::AV1);
+        assert_eq!(v.width, 64);
+        assert_eq!(v.height, 64);
 
-          },
-          _ => {
-              assert!(false, "Invalid test condition");
-          }
-      }
-  }
+        match v.codec_specific {
+            mp4::VideoCodecSpecific::AV1Config(ref av1c) => {
+                // TODO: test av1c fields once ffmpeg is updated
+                assert_eq!(av1c.profile, 0);
+                assert_eq!(av1c.level, 0);
+                assert_eq!(av1c.tier, 0);
+                assert_eq!(av1c.bit_depth, 8);
+                assert_eq!(av1c.monochrome, false);
+                assert_eq!(av1c.chroma_subsampling_x, 1);
+                assert_eq!(av1c.chroma_subsampling_y, 1);
+                assert_eq!(av1c.chroma_sample_position, 0);
+                assert_eq!(av1c.initial_presentation_delay_present, false);
+                assert_eq!(av1c.initial_presentation_delay_minus_one, 0);
+            },
+            _ => assert!(false, "Invalid test condition"),
+        }
+    }
 }

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -24,7 +24,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 log = "0.4"
-mp4parse = {version = "0.10.1", path = "../mp4parse"}
+mp4parse = {version = "0.11.0", path = "../mp4parse"}
 num-traits = "0.2.0"
 
 [dev-dependencies]

--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -61,7 +61,6 @@ fn dump_file(filename: &str) {
         for i in 0 .. counts {
             let mut track_info = Mp4parseTrackInfo {
                 track_type: Mp4parseTrackType::Audio,
-                codec: Mp4parseCodec::Unknown,
                 track_id: 0,
                 duration: 0,
                 media_time: 0,
@@ -82,6 +81,11 @@ fn dump_file(filename: &str) {
                     match mp4parse_get_track_audio_info(parser, i, &mut audio_info) {
                         Mp4parseStatus::Ok => {
                           println!("-- mp4parse_get_track_audio_info {:?}", audio_info);
+                          for i in 0 .. audio_info.sample_info_count as isize {
+                              let sample_info = audio_info.sample_info.offset(i);
+                              println!("  -- mp4parse_get_track_audio_info sample_info[{:?}] {:?}",
+                                       i, *sample_info);
+                          }
                         },
                         _ => {
                           println!("-- mp4parse_get_track_audio_info failed, track id: {}", i);
@@ -94,6 +98,11 @@ fn dump_file(filename: &str) {
                     match mp4parse_get_track_video_info(parser, i, &mut video_info) {
                         Mp4parseStatus::Ok => {
                           println!("-- mp4parse_get_track_video_info {:?}", video_info);
+                          for i in 0 .. video_info.sample_info_count as isize {
+                              let sample_info = video_info.sample_info.offset(i);
+                              println!("  -- mp4parse_get_track_video_info sample_info[{:?}] {:?}",
+                                       i, *sample_info);
+                          }
                         },
                         _ => {
                           println!("-- mp4parse_get_track_video_info failed, track id: {}", i);

--- a/mp4parse_capi/examples/test.cc
+++ b/mp4parse_capi/examples/test.cc
@@ -144,15 +144,17 @@ void test_arg_validation_with_data(const std::string& filename)
   assert(rv == MP4PARSE_STATUS_OK);
   assert(video.display_width == 320);
   assert(video.display_height == 240);
-  assert(video.image_width == 320);
-  assert(video.image_height == 240);
+  assert(video.sample_info_count == 1);
+  assert(video.sample_info[0].image_width == 320);
+  assert(video.sample_info[0].image_height == 240);
 
   Mp4parseTrackAudioInfo audio;
   rv = mp4parse_get_track_audio_info(parser, 1, &audio);
   assert(rv == MP4PARSE_STATUS_OK);
-  assert(audio.channels == 1);
-  assert(audio.bit_depth == 16);
-  assert(audio.sample_rate == 48000);
+  assert(audio.sample_info_count == 1);
+  assert(audio.sample_info[0].channels == 1);
+  assert(audio.sample_info[0].bit_depth == 16);
+  assert(audio.sample_info[0].sample_rate == 48000);
 
   // Test with an invalid track number.
 

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -111,7 +111,6 @@ impl Default for Mp4parseCodec {
 #[derive(Default, Debug)]
 pub struct Mp4parseTrackInfo {
     pub track_type: Mp4parseTrackType,
-    pub codec: Mp4parseCodec,
     pub track_id: u32,
     pub duration: u64,
     pub media_time: i64, // wants to be u64? understand how elst adjustment works
@@ -176,7 +175,8 @@ pub struct Mp4parseSinfInfo {
 
 #[repr(C)]
 #[derive(Default, Debug)]
-pub struct Mp4parseTrackAudioInfo {
+pub struct Mp4parseTrackAudioSampleInfo {
+    pub codec_type: Mp4parseCodec,
     pub channels: u16,
     pub bit_depth: u16,
     pub sample_rate: u32,
@@ -187,15 +187,51 @@ pub struct Mp4parseTrackAudioInfo {
 }
 
 #[repr(C)]
+#[derive(Debug)]
+pub struct Mp4parseTrackAudioInfo {
+    pub sample_info_count: u32,
+    pub sample_info: *const Mp4parseTrackAudioSampleInfo,
+}
+
+impl Default for Mp4parseTrackAudioInfo {
+    fn default() -> Self {
+        Self {
+            sample_info_count: 0,
+            sample_info: std::ptr::null(),
+        }
+    }
+}
+
+#[repr(C)]
 #[derive(Default, Debug)]
+pub struct Mp4parseTrackVideoSampleInfo {
+    pub codec_type: Mp4parseCodec,
+    pub image_width: u16,
+    pub image_height: u16,
+    pub extra_data: Mp4parseByteData,
+    pub protected_data: Mp4parseSinfInfo,
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct Mp4parseTrackVideoInfo {
     pub display_width: u32,
     pub display_height: u32,
-    pub image_width: u16,
-    pub image_height: u16,
     pub rotation: u16,
-    pub extra_data: Mp4parseByteData,
-    pub protected_data: Mp4parseSinfInfo,
+    pub sample_info_count: u32,
+    pub sample_info: *const Mp4parseTrackVideoSampleInfo,
+}
+
+impl Default for Mp4parseTrackVideoInfo {
+    fn default() -> Self {
+        Self {
+            display_width: 0,
+            display_height: 0,
+            rotation: 0,
+            sample_info_count: 0,
+            sample_info: std::ptr::null(),
+        }
+    }
 }
 
 #[repr(C)]
@@ -213,6 +249,12 @@ pub struct Mp4parseParser {
     opus_header: HashMap<u32, Vec<u8>>,
     pssh_data: Vec<u8>,
     sample_table: HashMap<u32, Vec<Mp4parseIndice>>,
+    // Store a mapping from track index (not id) to associated sample
+    // descriptions. Because each track has a variable number of sample
+    // descriptions, and because we need the data to live long enough to be
+    // copied out by callers, we store these on the parser struct.
+    audio_track_sample_descriptions: HashMap<u32, Vec<Mp4parseTrackAudioSampleInfo>>,
+    video_track_sample_descriptions: HashMap<u32, Vec<Mp4parseTrackVideoSampleInfo>>,
 }
 
 impl Mp4parseParser {
@@ -288,6 +330,8 @@ pub unsafe extern fn mp4parse_new(io: *const Mp4parseIo) -> *mut Mp4parseParser 
         opus_header: HashMap::new(),
         pssh_data: Vec::new(),
         sample_table: HashMap::new(),
+        audio_track_sample_descriptions: HashMap::new(),
+        video_track_sample_descriptions: HashMap::new(),
     });
 
     Box::into_raw(parser)
@@ -412,37 +456,6 @@ pub unsafe extern fn mp4parse_get_track_info(parser: *mut Mp4parseParser, track_
         TrackType::Unknown => return Mp4parseStatus::Unsupported,
     };
 
-    // Return UNKNOWN for unsupported format.
-    info.codec = match context.tracks[track_index].data {
-        Some(SampleEntry::Audio(ref audio)) => match audio.codec_specific {
-            AudioCodecSpecific::OpusSpecificBox(_) =>
-                Mp4parseCodec::Opus,
-            AudioCodecSpecific::FLACSpecificBox(_) =>
-                Mp4parseCodec::Flac,
-            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::AAC =>
-                Mp4parseCodec::Aac,
-            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
-                Mp4parseCodec::Mp3,
-            AudioCodecSpecific::ES_Descriptor(_) | AudioCodecSpecific::LPCM =>
-                Mp4parseCodec::Unknown,
-            AudioCodecSpecific::MP3 =>
-                Mp4parseCodec::Mp3,
-            AudioCodecSpecific::ALACSpecificBox(_) =>
-                Mp4parseCodec::Alac,
-        },
-        Some(SampleEntry::Video(ref video)) => match video.codec_specific {
-            VideoCodecSpecific::VPxConfig(_) =>
-                Mp4parseCodec::Vp9,
-            VideoCodecSpecific::AV1Config(_) =>
-                Mp4parseCodec::Av1,
-            VideoCodecSpecific::AVCConfig(_) =>
-                Mp4parseCodec::Avc,
-            VideoCodecSpecific::ESDSConfig(_) => // MP4V (14496-2) video is unsupported.
-                Mp4parseCodec::Unknown,
-        },
-        _ => Mp4parseCodec::Unknown,
-    };
-
     let track = &context.tracks[track_index];
 
     if let (Some(track_timescale),
@@ -493,7 +506,7 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut Mp4parseParser, 
     // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
-    let context = (*parser).context_mut();
+    let context = (*parser).context();
 
     if track_index as usize >= context.tracks.len() {
         return Mp4parseStatus::BadArg;
@@ -501,85 +514,126 @@ pub unsafe extern fn mp4parse_get_track_audio_info(parser: *mut Mp4parseParser, 
 
     let track = &context.tracks[track_index as usize];
 
-    match track.track_type {
-        TrackType::Audio => {}
-        _ => return Mp4parseStatus::Invalid,
+    if track.track_type != TrackType::Audio {
+        return Mp4parseStatus::Invalid;
+    }
+
+    // Handle track.stsd
+    let stsd = match track.stsd {
+        Some(ref stsd) => stsd,
+        None => return Mp4parseStatus::Invalid, // Stsd should be present
     };
 
-    let audio = match track.data {
-        Some(ref data) => data,
-        None => return Mp4parseStatus::Invalid,
-    };
+    if stsd.descriptions.len() == 0 {
+        return Mp4parseStatus::Invalid; // Should have at least 1 description
+    }
 
-    let audio = match *audio {
-        SampleEntry::Audio(ref x) => x,
-        _ => return Mp4parseStatus::Invalid,
-    };
+    let mut audio_sample_infos = Vec:: with_capacity(stsd.descriptions.len());
+    for description in stsd.descriptions.iter() {
+        let mut sample_info = Mp4parseTrackAudioSampleInfo::default();
+        let audio = match description {
+            SampleEntry::Audio(a) => a,
+            _ => return Mp4parseStatus::Invalid,
+        };
 
-    (*info).channels = audio.channelcount as u16;
-    (*info).bit_depth = audio.samplesize;
-    (*info).sample_rate = audio.samplerate as u32;
+        // UNKNOWN for unsupported format.
+        sample_info.codec_type = match audio.codec_specific {
+            AudioCodecSpecific::OpusSpecificBox(_) =>
+                Mp4parseCodec::Opus,
+            AudioCodecSpecific::FLACSpecificBox(_) =>
+                Mp4parseCodec::Flac,
+            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::AAC =>
+                Mp4parseCodec::Aac,
+            AudioCodecSpecific::ES_Descriptor(ref esds) if esds.audio_codec == CodecType::MP3 =>
+                Mp4parseCodec::Mp3,
+            AudioCodecSpecific::ES_Descriptor(_) | AudioCodecSpecific::LPCM =>
+                Mp4parseCodec::Unknown,
+            AudioCodecSpecific::MP3 =>
+                Mp4parseCodec::Mp3,
+            AudioCodecSpecific::ALACSpecificBox(_) =>
+                Mp4parseCodec::Alac,
+        };
+        sample_info.channels = audio.channelcount as u16;
+        sample_info.bit_depth = audio.samplesize;
+        sample_info.sample_rate = audio.samplerate as u32;
+        // sample_info.profile is handled below on a per case basis
 
-    match audio.codec_specific {
-        AudioCodecSpecific::ES_Descriptor(ref v) => {
-            if v.codec_esds.len() > std::u32::MAX as usize {
-                return Mp4parseStatus::Invalid;
-            }
-            (*info).extra_data.length = v.codec_esds.len() as u32;
-            (*info).extra_data.data = v.codec_esds.as_ptr();
-            (*info).codec_specific_config.length = v.decoder_specific_data.len() as u32;
-            (*info).codec_specific_config.data = v.decoder_specific_data.as_ptr();
-            if let Some(rate) = v.audio_sample_rate {
-                (*info).sample_rate = rate;
-            }
-            if let Some(channels) = v.audio_channel_count {
-                (*info).channels = channels;
-            }
-            if let Some(profile) = v.audio_object_type {
-                (*info).profile = profile;
-            }
-        }
-        AudioCodecSpecific::FLACSpecificBox(ref flac) => {
-            // Return the STREAMINFO metadata block in the codec_specific.
-            let streaminfo = &flac.blocks[0];
-            if streaminfo.block_type != 0 || streaminfo.data.len() != 34 {
-                return Mp4parseStatus::Invalid;
-            }
-            (*info).codec_specific_config.length = streaminfo.data.len() as u32;
-            (*info).codec_specific_config.data = streaminfo.data.as_ptr();
-        }
-        AudioCodecSpecific::OpusSpecificBox(ref opus) => {
-            let mut v = Vec::new();
-            match serialize_opus_header(opus, &mut v) {
-                Err(_) => {
+        match audio.codec_specific {
+            AudioCodecSpecific::ES_Descriptor(ref esds) => {
+                if esds.codec_esds.len() > std::u32::MAX as usize {
                     return Mp4parseStatus::Invalid;
                 }
-                Ok(_) => {
-                    let header = (*parser).opus_header_mut();
-                    header.insert(track_index, v);
-                    if let Some(v) = header.get(&track_index) {
-                        if v.len() > std::u32::MAX as usize {
-                            return Mp4parseStatus::Invalid;
+                sample_info.extra_data.length = esds.codec_esds.len() as u32;
+                sample_info.extra_data.data = esds.codec_esds.as_ptr();
+                sample_info.codec_specific_config.length = esds.decoder_specific_data.len() as u32;
+                sample_info.codec_specific_config.data = esds.decoder_specific_data.as_ptr();
+                if let Some(rate) = esds.audio_sample_rate {
+                    sample_info.sample_rate = rate;
+                }
+                if let Some(channels) = esds.audio_channel_count {
+                    sample_info.channels = channels;
+                }
+                if let Some(profile) = esds.audio_object_type {
+                    sample_info.profile = profile;
+                }
+            }
+            AudioCodecSpecific::FLACSpecificBox(ref flac) => {
+                // Return the STREAMINFO metadata block in the codec_specific.
+                let streaminfo = &flac.blocks[0];
+                if streaminfo.block_type != 0 || streaminfo.data.len() != 34 {
+                    return Mp4parseStatus::Invalid;
+                }
+                sample_info.codec_specific_config.length = streaminfo.data.len() as u32;
+                sample_info.codec_specific_config.data = streaminfo.data.as_ptr();
+            }
+            AudioCodecSpecific::OpusSpecificBox(ref opus) => {
+                let mut v = Vec::new();
+                match serialize_opus_header(opus, &mut v) {
+                    Err(_) => {
+                        return Mp4parseStatus::Invalid;
+                    }
+                    Ok(_) => {
+                        let header = (*parser).opus_header_mut();
+                        header.insert(track_index, v);
+                        if let Some(v) = header.get(&track_index) {
+                            if v.len() > std::u32::MAX as usize {
+                                return Mp4parseStatus::Invalid;
+                            }
+                            sample_info.codec_specific_config.length = v.len() as u32;
+                            sample_info.codec_specific_config.data = v.as_ptr();
                         }
-                        (*info).codec_specific_config.length = v.len() as u32;
-                        (*info).codec_specific_config.data = v.as_ptr();
                     }
                 }
             }
+            AudioCodecSpecific::ALACSpecificBox(ref alac) => {
+                sample_info.codec_specific_config.length = alac.data.len() as u32;
+                sample_info.codec_specific_config.data = alac.data.as_ptr();
+            }
+            AudioCodecSpecific::MP3 | AudioCodecSpecific::LPCM => (),
         }
-        AudioCodecSpecific::ALACSpecificBox(ref alac) => {
-            (*info).codec_specific_config.length = alac.data.len() as u32;
-            (*info).codec_specific_config.data = alac.data.as_ptr();
+
+        if let Some(p) = audio.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+            if let Some(ref tenc) = p.tenc {
+                sample_info.protected_data.is_encrypted = tenc.is_encrypted;
+                sample_info.protected_data.iv_size = tenc.iv_size;
+                sample_info.protected_data.kid.set_data(&(tenc.kid));
+            }
         }
-        AudioCodecSpecific::MP3 | AudioCodecSpecific::LPCM => (),
+        audio_sample_infos.push(sample_info);
     }
 
-    if let Some(p) = audio.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-        if let Some(ref tenc) = p.tenc {
-            (*info).protected_data.is_encrypted = tenc.is_encrypted;
-            (*info).protected_data.iv_size = tenc.iv_size;
-            (*info).protected_data.kid.set_data(&(tenc.kid));
-        }
+    (*parser).audio_track_sample_descriptions.insert(track_index, audio_sample_infos);
+    match (*parser).audio_track_sample_descriptions.get(&track_index) {
+        Some(sample_info) => {
+            if sample_info.len() > std::u32::MAX as usize {
+                // Should never happen due to upper limits on number of sample
+                // descriptions a track can have, but lets be safe.
+                return Mp4parseStatus::Invalid;
+            }
+            (*info).sample_info_count = sample_info.len() as u32;
+            (*info).sample_info = sample_info.as_ptr();
+        },
+        None => return Mp4parseStatus::Invalid, // Shouldn't happen, we just inserted the info!
     }
 
     Mp4parseStatus::Ok
@@ -595,7 +649,7 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut Mp4parseParser, 
     // Initialize fields to default values to ensure all fields are always valid.
     *info = Default::default();
 
-    let context = (*parser).context_mut();
+    let context = (*parser).context();
 
     if track_index as usize >= context.tracks.len() {
         return Mp4parseStatus::BadArg;
@@ -603,21 +657,11 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut Mp4parseParser, 
 
     let track = &context.tracks[track_index as usize];
 
-    match track.track_type {
-        TrackType::Video => {}
-        _ => return Mp4parseStatus::Invalid,
-    };
+    if track.track_type != TrackType::Video {
+        return Mp4parseStatus::Invalid;
+    }
 
-    let video = match track.data {
-        Some(ref data) => data,
-        None => return Mp4parseStatus::Invalid,
-    };
-
-    let video = match *video {
-        SampleEntry::Video(ref x) => x,
-        _ => return Mp4parseStatus::Invalid,
-    };
-
+    // Handle track.tkhd
     if let Some(ref tkhd) = track.tkhd {
         (*info).display_width = tkhd.width >> 16; // 16.16 fixed point
         (*info).display_height = tkhd.height >> 16; // 16.16 fixed point
@@ -632,24 +676,69 @@ pub unsafe extern fn mp4parse_get_track_video_info(parser: *mut Mp4parseParser, 
     } else {
         return Mp4parseStatus::Invalid;
     }
-    (*info).image_width = video.width;
-    (*info).image_height = video.height;
 
-    match video.codec_specific {
-        VideoCodecSpecific::AVCConfig(ref data) | VideoCodecSpecific::ESDSConfig(ref data) => {
-          (*info).extra_data.set_data(data);
-        },
-        _ => {}
+    // Handle track.stsd
+    let stsd = match track.stsd {
+        Some(ref stsd) => stsd,
+        None => return Mp4parseStatus::Invalid, // Stsd should be present
+    };
+
+    if stsd.descriptions.len() == 0 {
+        return Mp4parseStatus::Invalid; // Should have at least 1 description
     }
 
-    if let Some(p) = video.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
-        if let Some(ref tenc) = p.tenc {
-            (*info).protected_data.is_encrypted = tenc.is_encrypted;
-            (*info).protected_data.iv_size = tenc.iv_size;
-            (*info).protected_data.kid.set_data(&(tenc.kid));
+    let mut video_sample_infos = Vec:: with_capacity(stsd.descriptions.len());
+    for description in stsd.descriptions.iter() {
+        let mut sample_info = Mp4parseTrackVideoSampleInfo::default();
+        let video = match description {
+            SampleEntry::Video(v) => v,
+            _ => return Mp4parseStatus::Invalid,
+        };
+
+        // UNKNOWN for unsupported format.
+        sample_info.codec_type = match video.codec_specific {
+            VideoCodecSpecific::VPxConfig(_) =>
+                Mp4parseCodec::Vp9,
+            VideoCodecSpecific::AV1Config(_) =>
+                Mp4parseCodec::Av1,
+            VideoCodecSpecific::AVCConfig(_) =>
+                Mp4parseCodec::Avc,
+            VideoCodecSpecific::ESDSConfig(_) => // MP4V (14496-2) video is unsupported.
+                Mp4parseCodec::Unknown,
+        };
+        sample_info.image_width = video.width;
+        sample_info.image_height = video.height;
+
+        match video.codec_specific {
+            VideoCodecSpecific::AVCConfig(ref data) | VideoCodecSpecific::ESDSConfig(ref data) => {
+                sample_info.extra_data.set_data(data);
+            },
+            _ => {}
         }
+
+        if let Some(p) = video.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
+            if let Some(ref tenc) = p.tenc {
+                sample_info.protected_data.is_encrypted = tenc.is_encrypted;
+                sample_info.protected_data.iv_size = tenc.iv_size;
+                sample_info.protected_data.kid.set_data(&(tenc.kid));
+            }
+        }
+        video_sample_infos.push(sample_info);
     }
 
+    (*parser).video_track_sample_descriptions.insert(track_index, video_sample_infos);
+    match (*parser).video_track_sample_descriptions.get(&track_index) {
+        Some(sample_info) => {
+            if sample_info.len() > std::u32::MAX as usize {
+                // Should never happen due to upper limits on number of sample
+                // descriptions a track can have, but lets be safe.
+                return Mp4parseStatus::Invalid;
+            }
+            (*info).sample_info_count = sample_info.len() as u32;
+            (*info).sample_info = sample_info.as_ptr();
+        },
+        None => return Mp4parseStatus::Invalid, // Shouldn't happen, we just inserted the info!
+    }
     Mp4parseStatus::Ok
 }
 
@@ -1203,7 +1292,6 @@ fn arg_validation() {
 
         let mut dummy_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Video,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -1213,11 +1301,9 @@ fn arg_validation() {
         let mut dummy_video = Mp4parseTrackVideoInfo {
             display_width: 0,
             display_height: 0,
-            image_width: 0,
-            image_height: 0,
             rotation: 0,
-            extra_data: Mp4parseByteData::default(),
-            protected_data: Default::default(),
+            sample_info_count: 0,
+            sample_info: std::ptr::null(),
         };
         assert_eq!(Mp4parseStatus::BadArg, mp4parse_get_track_video_info(std::ptr::null_mut(), 0, &mut dummy_video));
 
@@ -1250,7 +1336,6 @@ fn arg_validation_with_parser() {
 
         let mut dummy_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Video,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -1260,11 +1345,9 @@ fn arg_validation_with_parser() {
         let mut dummy_video = Mp4parseTrackVideoInfo {
             display_width: 0,
             display_height: 0,
-            image_width: 0,
-            image_height: 0,
             rotation: 0,
-            extra_data: Mp4parseByteData::default(),
-            protected_data: Default::default(),
+            sample_info_count: 0,
+            sample_info: std::ptr::null(),
         };
         assert_eq!(Mp4parseStatus::BadArg, mp4parse_get_track_video_info(parser, 0, &mut dummy_video));
 
@@ -1314,81 +1397,61 @@ fn arg_validation_with_data() {
 
         let mut info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Video,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
         };
         assert_eq!(Mp4parseStatus::Ok, mp4parse_get_track_info(parser, 0, &mut info));
         assert_eq!(info.track_type, Mp4parseTrackType::Video);
-        assert_eq!(info.codec, Mp4parseCodec::Avc);
         assert_eq!(info.track_id, 1);
         assert_eq!(info.duration, 40000);
         assert_eq!(info.media_time, 0);
 
         assert_eq!(Mp4parseStatus::Ok, mp4parse_get_track_info(parser, 1, &mut info));
         assert_eq!(info.track_type, Mp4parseTrackType::Audio);
-        assert_eq!(info.codec, Mp4parseCodec::Aac);
         assert_eq!(info.track_id, 2);
         assert_eq!(info.duration, 61333);
         assert_eq!(info.media_time, 21333);
 
-        let mut video = Mp4parseTrackVideoInfo {
-            display_width: 0,
-            display_height: 0,
-            image_width: 0,
-            image_height: 0,
-            rotation: 0,
-            extra_data: Mp4parseByteData::default(),
-            protected_data: Default::default(),
-        };
+        let mut video = Mp4parseTrackVideoInfo::default();
         assert_eq!(Mp4parseStatus::Ok, mp4parse_get_track_video_info(parser, 0, &mut video));
         assert_eq!(video.display_width, 320);
         assert_eq!(video.display_height, 240);
-        assert_eq!(video.image_width, 320);
-        assert_eq!(video.image_height, 240);
+        assert_eq!(video.sample_info_count, 1);
 
-        let mut audio = Default::default();
+        assert_eq!((*video.sample_info).image_width, 320);
+        assert_eq!((*video.sample_info).image_height, 240);
+
+        let mut audio = Mp4parseTrackAudioInfo::default();
         assert_eq!(Mp4parseStatus::Ok, mp4parse_get_track_audio_info(parser, 1, &mut audio));
-        assert_eq!(audio.channels, 1);
-        assert_eq!(audio.bit_depth, 16);
-        assert_eq!(audio.sample_rate, 48000);
+        assert_eq!(audio.sample_info_count, 1);
+
+        assert_eq!((*audio.sample_info).channels, 1);
+        assert_eq!((*audio.sample_info).bit_depth, 16);
+        assert_eq!((*audio.sample_info).sample_rate, 48000);
 
         // Test with an invalid track number.
         let mut info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Video,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
         };
         assert_eq!(Mp4parseStatus::BadArg, mp4parse_get_track_info(parser, 3, &mut info));
         assert_eq!(info.track_type, Mp4parseTrackType::Video);
-        assert_eq!(info.codec, Mp4parseCodec::Unknown);
         assert_eq!(info.track_id, 0);
         assert_eq!(info.duration, 0);
         assert_eq!(info.media_time, 0);
 
-        let mut video = Mp4parseTrackVideoInfo {
-            display_width: 0,
-            display_height: 0,
-            image_width: 0,
-            image_height: 0,
-            rotation: 0,
-            extra_data: Mp4parseByteData::default(),
-            protected_data: Default::default(),
-        };
+        let mut video = Mp4parseTrackVideoInfo::default();
         assert_eq!(Mp4parseStatus::BadArg, mp4parse_get_track_video_info(parser, 3, &mut video));
         assert_eq!(video.display_width, 0);
         assert_eq!(video.display_height, 0);
-        assert_eq!(video.image_width, 0);
-        assert_eq!(video.image_height, 0);
+        assert_eq!(video.sample_info_count, 0);
 
         let mut audio = Default::default();
         assert_eq!(Mp4parseStatus::BadArg, mp4parse_get_track_audio_info(parser, 3, &mut audio));
-        assert_eq!(audio.channels, 0);
-        assert_eq!(audio.bit_depth, 0);
-        assert_eq!(audio.sample_rate, 0);
+        assert_eq!(audio.sample_info_count, 0);
 
         mp4parse_free(parser);
     }

--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -32,7 +32,6 @@ fn parse_fragment() {
 
         let mut track_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Audio,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -40,10 +39,20 @@ fn parse_fragment() {
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
-        assert_eq!(track_info.codec, Mp4parseCodec::Aac);
         assert_eq!(track_info.track_id, 1);
         assert_eq!(track_info.duration, 0);
         assert_eq!(track_info.media_time, 0);
+
+        let mut audio = Default::default();
+        rv = mp4parse_get_track_audio_info(parser, 0, &mut audio);
+        assert_eq!(rv, Mp4parseStatus::Ok);
+        assert_eq!(audio.sample_info_count, 1);
+
+        assert_eq!((*audio.sample_info).channels, 2);
+        assert_eq!((*audio.sample_info).bit_depth, 16);
+        assert_eq!((*audio.sample_info).sample_rate, 22050);
+        assert_eq!((*audio.sample_info).extra_data.length, 27);
+        assert_eq!((*audio.sample_info).codec_specific_config.length, 2);
 
         let mut is_fragmented_file: u8 = 0;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);
@@ -83,7 +92,6 @@ fn parse_opus_fragment() {
 
         let mut track_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Audio,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -91,7 +99,6 @@ fn parse_opus_fragment() {
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
-        assert_eq!(track_info.codec, Mp4parseCodec::Opus);
         assert_eq!(track_info.track_id, 1);
         assert_eq!(track_info.duration, 0);
         assert_eq!(track_info.media_time, 0);
@@ -99,11 +106,13 @@ fn parse_opus_fragment() {
         let mut audio = Default::default();
         rv = mp4parse_get_track_audio_info(parser, 0, &mut audio);
         assert_eq!(rv, Mp4parseStatus::Ok);
-        assert_eq!(audio.channels, 1);
-        assert_eq!(audio.bit_depth, 16);
-        assert_eq!(audio.sample_rate, 48000);
-        assert_eq!(audio.extra_data.length, 0);
-        assert_eq!(audio.codec_specific_config.length, 19);
+        assert_eq!(audio.sample_info_count, 1);
+
+        assert_eq!((*audio.sample_info).channels, 1);
+        assert_eq!((*audio.sample_info).bit_depth, 16);
+        assert_eq!((*audio.sample_info).sample_rate, 48000);
+        assert_eq!((*audio.sample_info).extra_data.length, 0);
+        assert_eq!((*audio.sample_info).codec_specific_config.length, 19);
 
         let mut is_fragmented_file: u8 = 0;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);

--- a/mp4parse_capi/tests/test_rotation.rs
+++ b/mp4parse_capi/tests/test_rotation.rs
@@ -30,15 +30,7 @@ fn parse_rotation() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 1);
 
-        let mut video = Mp4parseTrackVideoInfo {
-            display_width: 0,
-            display_height: 0,
-            image_width: 0,
-            image_height: 0,
-            rotation: 0,
-            extra_data: Mp4parseByteData::default(),
-            protected_data: Default::default(),
-        };
+        let mut video = Mp4parseTrackVideoInfo::default();
 
         let rv = mp4parse_get_track_video_info(parser, 0, &mut video);
         assert_eq!(rv, Mp4parseStatus::Ok);

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -32,7 +32,6 @@ fn parse_sample_table() {
 
         let mut track_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Audio,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -40,7 +39,6 @@ fn parse_sample_table() {
         rv = mp4parse_get_track_info(parser, 1, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
-        assert_eq!(track_info.codec, Mp4parseCodec::Aac);
 
         // Check audio smaple table
         let mut is_fragmented_file: u8 = 0;
@@ -63,7 +61,6 @@ fn parse_sample_table() {
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Video);
-        assert_eq!(track_info.codec, Mp4parseCodec::Avc);
 
         let mut is_fragmented_file: u8 = 0;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);
@@ -117,7 +114,6 @@ fn parse_sample_table_with_elst() {
 
         let mut track_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Audio,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -125,7 +121,6 @@ fn parse_sample_table_with_elst() {
         rv = mp4parse_get_track_info(parser, 1, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
-        assert_eq!(track_info.codec, Mp4parseCodec::Aac);
 
         // Check audio sample table
         let mut is_fragmented_file: u8 = std::u8::MAX;
@@ -173,7 +168,6 @@ fn parse_sample_table_with_negative_ctts() {
 
         let mut track_info = Mp4parseTrackInfo {
             track_type: Mp4parseTrackType::Audio,
-            codec: Mp4parseCodec::Unknown,
             track_id: 0,
             duration: 0,
             media_time: 0,
@@ -181,7 +175,6 @@ fn parse_sample_table_with_negative_ctts() {
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Video);
-        assert_eq!(track_info.codec, Mp4parseCodec::Avc);
 
         let mut is_fragmented_file: u8 = std::u8::MAX;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);


### PR DESCRIPTION
The mp4 spec allows for tracks to have multiple sample descriptions.
This is done to allow for different codings within a track. Cases of
this being done appear to be rare, and historically the parser was able
to assume a single description was used. However, instances of multiple
descriptions are appearring in encrypted content packaged by Google's
Shaka packager. To avoid compatibility issues, and as this behaviour is
specified, we should handle and expose multiple samples descriptions per
track.

Technically, this changes how we expose the contents of stsd boxes.
Previouslly we would map a combination of the contained entires to a
single `data` member of the associated track. With this change, a track
now exposes each of its sample descriptions. The data member on tracks
has been removed.

For consumers, if a single sample description is present on a track,
this can be handled in a similar fashion as with `track.data`. If
multiple sample descriptions exist, handling is more complex, and the
relevant sample description must be looked up for samples by the consumer.
However, this should be preferred to offering an incomplete view of
the metadata.

The c-api and tests are also updated to avoid bustages.