### PR TITLE
capi tests: use default() for structs and add back some codec checks.

### DIFF
--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -30,12 +30,7 @@ fn parse_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 1);
 
-        let mut track_info = Mp4parseTrackInfo {
-            track_type: Mp4parseTrackType::Audio,
-            track_id: 0,
-            duration: 0,
-            media_time: 0,
-        };
+        let mut track_info = Mp4parseTrackInfo::default();
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
@@ -48,6 +43,7 @@ fn parse_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(audio.sample_info_count, 1);
 
+        assert_eq!((*audio.sample_info).codec_type, Mp4parseCodec::Aac);
         assert_eq!((*audio.sample_info).channels, 2);
         assert_eq!((*audio.sample_info).bit_depth, 16);
         assert_eq!((*audio.sample_info).sample_rate, 22050);
@@ -59,9 +55,7 @@ fn parse_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(is_fragmented_file, 1);
 
-        let mut fragment_info = Mp4parseFragmentInfo {
-            fragment_duration: 0,
-        };
+        let mut fragment_info = Mp4parseFragmentInfo::default();
         rv = mp4parse_get_fragment_info(parser, &mut fragment_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(fragment_info.fragment_duration, 10032000);
@@ -90,12 +84,7 @@ fn parse_opus_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 1);
 
-        let mut track_info = Mp4parseTrackInfo {
-            track_type: Mp4parseTrackType::Audio,
-            track_id: 0,
-            duration: 0,
-            media_time: 0,
-        };
+        let mut track_info = Mp4parseTrackInfo::default();
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
@@ -108,6 +97,7 @@ fn parse_opus_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(audio.sample_info_count, 1);
 
+        assert_eq!((*audio.sample_info).codec_type, Mp4parseCodec::Opus);
         assert_eq!((*audio.sample_info).channels, 1);
         assert_eq!((*audio.sample_info).bit_depth, 16);
         assert_eq!((*audio.sample_info).sample_rate, 48000);
@@ -119,9 +109,7 @@ fn parse_opus_fragment() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(is_fragmented_file, 1);
 
-        let mut fragment_info = Mp4parseFragmentInfo {
-            fragment_duration: 0,
-        };
+        let mut fragment_info = Mp4parseFragmentInfo::default();
         rv = mp4parse_get_fragment_info(parser, &mut fragment_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
 

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -30,12 +30,7 @@ fn parse_sample_table() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 2);
 
-        let mut track_info = Mp4parseTrackInfo {
-            track_type: Mp4parseTrackType::Audio,
-            track_id: 0,
-            duration: 0,
-            media_time: 0,
-        };
+        let mut track_info = Mp4parseTrackInfo::default();
         rv = mp4parse_get_track_info(parser, 1, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
@@ -112,12 +107,7 @@ fn parse_sample_table_with_elst() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 2);
 
-        let mut track_info = Mp4parseTrackInfo {
-            track_type: Mp4parseTrackType::Audio,
-            track_id: 0,
-            duration: 0,
-            media_time: 0,
-        };
+        let mut track_info = Mp4parseTrackInfo::default();
         rv = mp4parse_get_track_info(parser, 1, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
@@ -166,12 +156,7 @@ fn parse_sample_table_with_negative_ctts() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(counts, 1);
 
-        let mut track_info = Mp4parseTrackInfo {
-            track_type: Mp4parseTrackType::Audio,
-            track_id: 0,
-            duration: 0,
-            media_time: 0,
-        };
+        let mut track_info = Mp4parseTrackInfo::default();
         rv = mp4parse_get_track_info(parser, 0, &mut track_info);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Video);


### PR DESCRIPTION
- There are a number of cases where structs that have default values are
being created with explicit values in the capi tests. We can just use
default(), it makes the tests more concise, and avoids confusion where
readers may think we're intentionally using explicit values for
programatic reasons.
- Recent changes have moved codec information from track structures to
sample description structures -- as a single track may have multiple
different sample descriptions with their own codecs. In doing so, I had
removed some codec checks from our tests. Restore some of these checks
in test_fragment.rs, so that we have coverage, and as that test inspects
at the sample description level.