### PR TITLE
Handle schm box

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -40,7 +40,7 @@ macro_rules! box_database {
     }
 }
 
-#[derive(Default, PartialEq)]
+#[derive(Default, PartialEq, Clone)]
 pub struct FourCC {
     pub value: String
 }
@@ -137,6 +137,7 @@ box_database!(
     TrackEncryptionBox                0x74656e63, // "tenc"
     ProtectionSchemeInformationBox    0x73696e66, // "sinf"
     OriginalFormatBox                 0x66726d61, // "frma"
+    SchemeTypeBox                     0x7363686d, // "schm"
     MP3AudioSampleEntry               0x2e6d7033, // ".mp3" - from F4V.
     CompositionOffsetBox              0x63747473, // "ctts"
     LPCMAudioSampleEntry              0x6C70636D, // "lpcm" - quicktime atom

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -163,6 +163,11 @@ fn public_audio_tenc() {
         match a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
             Some(ref p) => {
                 assert_eq!(p.code_name, "mp4a");
+                if let Some(ref schm) = p.scheme_type {
+                    assert_eq!(schm.scheme_type.value, "cenc");
+                } else {
+                    assert!(false, "Expected scheme type info");
+                }
                 if let Some(ref tenc) = p.tenc {
                     assert!(tenc.is_encrypted > 0);
                     assert_eq!(tenc.iv_size, 16);
@@ -217,6 +222,11 @@ fn public_video_cenc() {
         match v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
             Some(ref p) => {
                 assert_eq!(p.code_name, "avc1");
+                if let Some(ref schm) = p.scheme_type {
+                    assert_eq!(schm.scheme_type.value, "cenc");
+                } else {
+                    assert!(false, "Expected scheme type info");
+                }
                 if let Some(ref tenc) = p.tenc {
                     assert!(tenc.is_encrypted > 0);
                     assert_eq!(tenc.iv_size, 16);
@@ -284,6 +294,11 @@ fn publicaudio_cbcs() {
                     if let Some(p) = a.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
                         found_encrypted_sample_description = true;
                         assert_eq!(p.code_name, "mp4a");
+                        if let Some(ref schm) = p.scheme_type {
+                            assert_eq!(schm.scheme_type.value, "cbcs");
+                        } else {
+                            assert!(false, "Expected scheme type info");
+                        }
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);
                             assert_eq!(tenc.iv_size, 0);
@@ -360,6 +375,11 @@ fn public_video_cbcs() {
                     if let Some(p) = v.protection_info.iter().find(|sinf| sinf.tenc.is_some()) {
                         found_encrypted_sample_description = true;
                         assert_eq!(p.code_name, "avc1");
+                        if let Some(ref schm) = p.scheme_type {
+                            assert_eq!(schm.scheme_type.value, "cbcs");
+                        } else {
+                            assert!(false, "Expected scheme type info");
+                        }
                         if let Some(ref tenc) = p.tenc {
                             assert!(tenc.is_encrypted > 0);
                             assert_eq!(tenc.iv_size, 0);

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -24,7 +24,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 log = "0.4"
-mp4parse = {version = "0.11.0", path = "../mp4parse"}
+mp4parse = {version = "0.11.1", path = "../mp4parse"}
 num-traits = "0.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The SchemeType box stores a four character code representing the
encryption scheme used for a track. It also stores a version number for
the scheme used. Historically the scheme could be determined by other
metadata, without explicitly reading the FourCC. This appears to still be
the case, however, parsing this information is useful because:
- It's easier to read the encryption scheme from the scheme type box
that deduce it from other values.
- We can use the explicit scheme type to checksum the other encryption
values and make sure they're sane for a given type.
- If I'm wrong about being able to deduce all schemes from other
metadata, we may require the scheme type to handle certain encrypted
media.

The scheme type is read and exposed in both the rust and C APIs. The
scheme version is currently not exposed for C, as it doesn't appear to
have an impact to how MP4s should be handled in the current spec.

Add tests to verify scheme parsing for encrypted and non encrypted
cases.

Bump version numbers given the API change.