### PR TITLE
Remove oclint work around for travis now that it's not needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ os:
   - linux
   - osx
   - windows
-
-before_install:
-  # Work around https://github.com/travis-ci/travis-ci/issues/8826, when that
-  # issue is fixed we can just include gcc in the addons
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@5; fi
   
 addons:
   apt:
@@ -20,6 +14,9 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-5
+  homebrew:
+    packages:
+      - gcc@5
 
 env:
   global:


### PR DESCRIPTION
Per [this](https://changelog.travis-ci.com/oclint-is-removed-from-mac-builds-79270) we no longer need the work around for travis, and indeed need it removed to avoid failures.

Edit: should it be useful, see also https://github.com/travis-ci/travis-ci/issues/8826 for historical context.