### PR TITLE
Zero initialize Vec returned from mp4parse_fallible branch of allocate_read_buf.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -42,8 +42,8 @@ const BUF_SIZE_LIMIT: usize = 1024 * 1024;
 // frame per table entry in 30 fps.
 const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24 * 7;
 
-// TODO: vec_push() and vec_reserve() needs to be replaced when Rust supports
-// fallible memory allocation in raw_vec.
+// TODO: vec_push() needs to be replaced when Rust supports fallible memory
+// allocation in raw_vec.
 #[allow(unreachable_code)]
 pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
     #[cfg(feature = "mp4parse_fallible")]
@@ -56,23 +56,12 @@ pub fn vec_push<T>(vec: &mut Vec<T>, val: T) -> std::result::Result<(), ()> {
 }
 
 #[allow(unreachable_code)]
-pub fn vec_reserve<T>(vec: &mut Vec<T>, size: usize) -> std::result::Result<(), ()> {
-    #[cfg(feature = "mp4parse_fallible")]
-    {
-        return FallibleVec::try_reserve(vec, size);
-    }
-
-    vec.reserve(size);
-    Ok(())
-}
-
-#[allow(unreachable_code)]
 fn allocate_read_buf(size: usize) -> std::result::Result<Vec<u8>, ()> {
     #[cfg(feature = "mp4parse_fallible")]
     {
         let mut buf: Vec<u8> = Vec::new();
         FallibleVec::try_reserve(&mut buf, size)?;
-        unsafe { buf.set_len(size); }
+        buf.extend(std::iter::repeat(0).take(size));
         return Ok(buf);
     }
 


### PR DESCRIPTION
Zero initialize Vec returned from mp4parse_fallible branch of allocate_read_buf.

Also delete vec_reserve, which is completely unused.

Closes #172.

r? @SingingTree please