### PR TITLE
Switch to newer "..=" inclusive range syntax to avoid deprecation warnings on Nightly.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -615,7 +615,7 @@ fn read_box_header<T: ReadBytesExt>(src: &mut T) -> Result<BoxHeader> {
             }
             size64
         }
-        2...7 => return Err(Error::InvalidData("malformed size")),
+        2 ..= 7 => return Err(Error::InvalidData("malformed size")),
         _ => size32 as u64,
     };
     let mut offset = match size32 {
@@ -1274,7 +1274,7 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
             // According to spec, Version0 shoule be used when version == 0;
             // however, some buggy contents have negative value when version == 0.
             // So we always use Version1 here.
-            0...1 => {
+            0 ..= 1 => {
                 let count = be_u32_with_limit(src)?;
                 let offset = TimeOffsetVersion::Version1(be_i32(src)?);
                 (count, offset)
@@ -1569,7 +1569,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     };
 
     match audio_object_type {
-        1 ... 4 | 6 | 7 | 17 | 19 ... 23 => {
+        1 ..= 4 | 6 | 7 | 17 | 19 ..= 23 => {
             if sample_frequency.is_none() {
                 return Err(Error::Unsupported("unknown frequency"));
             }
@@ -1586,17 +1586,17 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
             // to associate an implied sampling frequency with the desired
             // sampling frequency dependent tables.
             let sample_frequency_value = match sample_frequency.unwrap() {
-                0 ... 9390 => 8000,
-                9391 ... 11501 => 11025,
-                11502 ... 13855 => 12000,
-                13856 ... 18782 => 16000,
-                18783 ... 23003 => 22050,
-                23004 ... 27712 => 24000,
-                27713 ... 37565 => 32000,
-                37566 ... 46008 => 44100,
-                46009 ... 55425 => 48000,
-                55426 ... 75131 => 64000,
-                75132 ... 92016 => 88200,
+                0 ..= 9390 => 8000,
+                9391 ..= 11501 => 11025,
+                11502 ..= 13855 => 12000,
+                13856 ..= 18782 => 16000,
+                18783 ..= 23003 => 22050,
+                23004 ..= 27712 => 24000,
+                27713 ..= 37565 => 32000,
+                37566 ..= 46008 => 44100,
+                46009 ..= 55425 => 48000,
+                55426 ..= 75131 => 64000,
+                75132 ..= 92016 => 88200,
                 _ => 96000
             };
 
@@ -1643,7 +1643,7 @@ fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
                     _channel_counts += read_surround_channel_count(bit_reader, num_lfe_channel)?;
                     _channel_counts
                 },
-                1 ... 7 => channel_configuration,
+                1 ..= 7 => channel_configuration,
                 // Amendment 4 of the AAC standard in 2013 below
                 11 => 7, // 6.1 Amendment 4 of the AAC standard in 2013
                 12 | 14 => 8, // 7.1 (a/d) of ITU BS.2159


### PR DESCRIPTION
"..=" has been stable since early 2018, so it's safe to use.

r? @SingingTree please