### PR TITLE
Update vpx config box names

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.11.3"
+version = "0.11.4"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -459,8 +459,8 @@ fn read_vpcc_version_1() {
         Ok(vpcc) => {
             assert_eq!(vpcc.bit_depth, 8);
             assert_eq!(vpcc.chroma_subsampling, 3);
-            assert_eq!(vpcc.video_full_range, false);
-            assert_eq!(vpcc.matrix.unwrap(), 1);
+            assert_eq!(vpcc.video_full_range_flag, false);
+            assert_eq!(vpcc.matrix_coefficients.unwrap(), 1);
         },
         _ => panic!("vpcc parsing error"),
     }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -71,7 +71,7 @@ fn public_api() {
                     mp4::VideoCodecSpecific::VPxConfig(ref vpx) => {
                         // We don't enter in here, we just check if fields are public.
                         assert!(vpx.bit_depth > 0);
-                        assert!(vpx.color_space > 0);
+                        assert!(vpx.colour_primaries > 0);
                         assert!(vpx.chroma_subsampling > 0);
                         assert!(!vpx.codec_init.is_empty());
                         "VPx"


### PR DESCRIPTION
Seeks to fix https://github.com/mozilla/mp4parse-rust/issues/176 and add some more documentation along the way.

Let me know if some other formatting is preferred for the multilines that were broken. I based this on rustfmt's defaults.