### PR TITLE
Add clippy config to travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ env:
     - RELEASE=
     - RELEASE=--release
 
+# Make sure clippy is installed, if it fails on nightly fall back to installing from repo.
+before_script:
+   - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+
 script:
+  - cargo clippy --all --all-targets $RELEASE -- -D warnings
   - cargo test --all --verbose $RELEASE
   - cargo doc --package mp4parse_capi


### PR DESCRIPTION
This should have travis run clippy as well as fail if any warnings are
found (not just in clippy, but elsewhere too).

I *think* this should work, but given the matrix of configs it's possible something breaks, so suggest we keep an eye on travis for a bit if we merge this.