### PR TITLE
Replace casts with infallible or error-checked conversions

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -30,6 +30,7 @@ bitreader = { version = "0.3.0" }
 num-traits = "0.2.0"
 mp4parse_fallible = { version = "0.0.1", optional = true }
 log = "0.4"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 test-assembler = "0.1.2"


### PR DESCRIPTION
Add `to_u64` and `to_usize` trait functions for infallible conversions
which can be checked at compile time to be platform safe.

Additionally, convert some arithmetic to checked versions so we can
error rather than panic or give invalid results on overflow.

Remove some unnecessary trait bounds on struct definitions.

Update `skip` to avoid allocating a buffer.