### PR TITLE
read_avif: Collapse primary_items_extents_data with Vec::concat instead of Iterator::flatten.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1338,7 +1338,7 @@ pub fn read_avif<T: Read>(f: &mut T, context: &mut AvifContext) -> Result<()> {
         }
     }
 
-    context.primary_item = primary_item_extents_data.into_iter().flatten().collect();
+    context.primary_item = primary_item_extents_data.concat();
 
     Ok(())
 }


### PR DESCRIPTION
This improves the runtime of the public_avif_read_samples test from >20s to
<0.3s.  In optimized builds, there's no performance issue with
Iterator::flatten, so the runtime of both versions are the same.