### PR TITLE
Fix CI by undoing the reordering of extern crate statements

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -35,8 +35,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-extern crate byteorder;
 extern crate mp4parse;
+#[rustfmt::skip] // See https://github.com/mozilla/mp4parse-rust/issues/197#issuecomment-596910016
+extern crate byteorder;
 extern crate num_traits;
 
 use byteorder::WriteBytesExt;


### PR DESCRIPTION
This was changed by rustfmt, but it breaks `build_ffi_test` for some reason.
Add annotation to keep rustfmt from reordering them again (at least until we
come up with a better fix).

See https://github.com/mozilla/mp4parse-rust/issues/197#issuecomment-596910016