### PR TITLE
Refactor mp4parse_new to return Mp4parseStatus

### DIFF
--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -28,8 +28,8 @@ fn dump_file(filename: &str) {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let rv = mp4parse_new(&io, &mut parser);
 
         match rv {
             Mp4parseStatus::Ok => (),

--- a/mp4parse_capi/examples/test.cc
+++ b/mp4parse_capi/examples/test.cc
@@ -35,24 +35,23 @@ intptr_t io_read(uint8_t *buffer, uintptr_t size, void *userdata)
 
 void test_arg_validation()
 {
-  Mp4parseParser *parser = mp4parse_new(nullptr, nullptr);
-  assert(parser == nullptr);
+  Mp4parseParser *parser = nullptr;
+  Mp4parseStatus rv = mp4parse_new(nullptr, nullptr);
+  assert(rv == MP4PARSE_STATUS_BAD_ARG);
 
-  Mp4parseStatus rv = MP4PARSE_STATUS_INVALID;
-  parser = mp4parse_new(nullptr, &rv);
+  rv = mp4parse_new(nullptr, &parser);
   assert(rv == MP4PARSE_STATUS_BAD_ARG);
   assert(parser == nullptr);
 
   Mp4parseIo io = { nullptr, nullptr };
-  rv = MP4PARSE_STATUS_INVALID;
-  parser = mp4parse_new(&io, &rv);
+  rv = mp4parse_new(&io, &parser);
   assert(rv == MP4PARSE_STATUS_BAD_ARG);
   assert(parser == nullptr);
 
   int dummy_value = 42;
   io = { nullptr, &dummy_value };
-  rv = MP4PARSE_STATUS_INVALID;
-  parser = mp4parse_new(&io, &rv);
+  parser = nullptr;
+  rv = mp4parse_new(&io, &parser);
   assert(rv == MP4PARSE_STATUS_BAD_ARG);
   assert(parser == nullptr);
 
@@ -75,8 +74,8 @@ void test_arg_validation_with_parser()
 {
   int dummy_value = 42;
   Mp4parseIo io = { error_read, &dummy_value };
-  Mp4parseStatus rv = MP4PARSE_STATUS_INVALID;
-  Mp4parseParser *parser = mp4parse_new(&io, &rv);
+  Mp4parseParser *parser = nullptr;
+  Mp4parseStatus rv = mp4parse_new(&io, &parser);
   assert(rv == MP4PARSE_STATUS_IO);
   assert(parser == nullptr);
 
@@ -97,8 +96,8 @@ void test_arg_validation_with_data(const std::string& filename)
   FILE* f = fopen(filename.c_str(), "rb");
   assert(f != nullptr);
   Mp4parseIo io = { io_read, f };
-  Mp4parseStatus rv = MP4PARSE_STATUS_INVALID;
-  Mp4parseParser *parser = mp4parse_new(&io, &rv);
+  Mp4parseParser *parser = nullptr;
+  Mp4parseStatus rv = mp4parse_new(&io, &parser);
   assert(rv == MP4PARSE_STATUS_OK);
   assert(parser != nullptr);
 
@@ -183,8 +182,8 @@ int32_t read_file(const char* filename)
 
   fprintf(stderr, "Parsing file '%s'.\n", filename);
   Mp4parseIo io = { io_read, f };
-  Mp4parseStatus rv = MP4PARSE_STATUS_INVALID;
-  Mp4parseParser *parser = mp4parse_new(&io, &rv);
+  Mp4parseParser *parser = nullptr;
+  Mp4parseStatus rv = mp4parse_new(&io, &parser);
 
   if (rv != MP4PARSE_STATUS_OK) {
     assert(parser == nullptr);

--- a/mp4parse_capi/tests/test_chunk_out_of_range.rs
+++ b/mp4parse_capi/tests/test_chunk_out_of_range.rs
@@ -20,8 +20,8 @@ fn parse_out_of_chunk_range() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 

--- a/mp4parse_capi/tests/test_encryption.rs
+++ b/mp4parse_capi/tests/test_encryption.rs
@@ -21,8 +21,8 @@ fn parse_cenc() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
         let mut counts: u32 = 0;
@@ -104,8 +104,8 @@ fn parse_cbcs() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
         let mut counts: u32 = 0;
@@ -166,8 +166,8 @@ fn parse_unencrypted() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 

--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -20,8 +20,8 @@ fn parse_fragment() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 
@@ -73,8 +73,8 @@ fn parse_opus_fragment() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 

--- a/mp4parse_capi/tests/test_rotation.rs
+++ b/mp4parse_capi/tests/test_rotation.rs
@@ -20,8 +20,8 @@ fn parse_rotation() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -21,8 +21,8 @@ fn parse_sample_table() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 
@@ -140,8 +140,8 @@ fn parse_sample_table_with_elst() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 
@@ -210,8 +210,8 @@ fn parse_sample_table_with_negative_ctts() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let mut rv = mp4parse_new(&io, &mut parser);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());
 

--- a/mp4parse_capi/tests/test_workaround_stsc.rs
+++ b/mp4parse_capi/tests/test_workaround_stsc.rs
@@ -20,8 +20,8 @@ fn parse_invalid_stsc_table() {
     };
 
     unsafe {
-        let mut rv = Mp4parseStatus::Invalid;
-        let parser = mp4parse_new(&io, &mut rv);
+        let mut parser = std::ptr::null_mut();
+        let rv = mp4parse_new(&io, &mut parser);
 
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert!(!parser.is_null());


### PR DESCRIPTION
https://github.com/mozilla/mp4parse-rust/pull/200#discussion_r390008980 was a good suggestion; I just didn't see it before merging https://github.com/mozilla/mp4parse-rust/pull/200, so here it is.

The Mp4parseParser is now set through an output parameter. Returning a status
is more consistent with the rest of the API and results in somewhat simpler code.

Equivalent changes for mp4parse_avif_new as well.