### PR TITLE
Added atom for JPEG

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -201,4 +201,5 @@ box_database!(
     SortArtistEntry                   0x736f_6172, // "soar"
     SortAlbumArtistEntry              0x736f_6161, // "soaa"
     SortComposerEntry                 0x736f_636f, // "soco"
+    QTJPEGAtom                        0x4a50_4547, // "JPEG" - quicktime atom
 );


### PR DESCRIPTION
I forgot to submit this one a while back.

The JPEG atom is found in Canon CR3 files.