### PR TITLE
Disable the ahash-compile-time-rng feature of hashbrown that makes bu…

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -27,7 +27,8 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-hashbrown = "0.7.1"
+# Disable the ahash-compile-time-rng feature of hashbrown that makes builds unreproducible.
+hashbrown = { version = "0.7.1", default-features = false, features = ["ahash", "inline-more"]}
 num-traits = "0.2.0"
 log = "0.4"
 static_assertions = "1.1.0"


### PR DESCRIPTION
…ilds unreproducible.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1637140