### PR TITLE
Improve debug format implementations

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -44,7 +44,7 @@ macro_rules! box_database {
         impl fmt::Debug for BoxType {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 let fourcc: FourCC = From::from(self.clone());
-                write!(f, "{}", fourcc)
+                fourcc.fmt(f)
             }
         }
     }
@@ -79,7 +79,7 @@ impl From<[u8; 4]> for FourCC {
 impl fmt::Debug for FourCC {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match std::str::from_utf8(&self.value) {
-            Ok(s) => write!(f, "{}", s),
+            Ok(s) => f.write_str(s),
             Err(_) => self.value.fmt(f),
         }
     }
@@ -87,10 +87,7 @@ impl fmt::Debug for FourCC {
 
 impl fmt::Display for FourCC {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match std::str::from_utf8(&self.value) {
-            Ok(s) => write!(f, "{}", s),
-            Err(_) => write!(f, "null"),
-        }
+        f.write_str(std::str::from_utf8(&self.value).unwrap_or("null"))
     }
 }
 

--- a/mp4parse/src/fallible.rs
+++ b/mp4parse/src/fallible.rs
@@ -188,7 +188,7 @@ pub struct TryVec<T> {
 
 impl<T: std::fmt::Debug> std::fmt::Debug for TryVec<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.inner)
+        self.inner.fmt(f)
     }
 }
 

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1455,7 +1455,7 @@ struct U32BE(u32);
 impl std::fmt::Display for U32BE {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match std::str::from_utf8(&self.0.to_be_bytes()) {
-            Ok(s) => write!(f, "{}", s),
+            Ok(s) => f.write_str(s),
             Err(_) => write!(f, "{:x?}", self.0),
         }
     }


### PR DESCRIPTION
Using `{:?}` inside `Debug::fmt` implementation loses formatter flags, e.g. breaks `{:#?}` formatting.

I've also simplified other debug implementations where `write!` formatting machinery was unnecessary for printing a single string.

