### PR TITLE
Return error for overflow in create_sample_table

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1439,8 +1439,8 @@ fn create_sample_table(track: &Track, track_offset_time: i64) -> Option<TryVec<M
 
         match (start_composition, end_composition, start_decode) {
             (Some(s_c), Some(e_c), Some(s_d)) => {
-                sample.start_composition = s_c + track_offset_time;
-                sample.end_composition = e_c + track_offset_time;
+                sample.start_composition = s_c.checked_add(track_offset_time)?;
+                sample.end_composition = e_c.checked_add(track_offset_time)?;
                 sample.start_decode = s_d;
             }
             _ => return None,


### PR DESCRIPTION
This is a fairly minimal fix to unblock fuzz testing. I'll follow up with
a more general fix by wrapping these types and only allowing checked
arithmetic.

See https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24883