### PR TITLE
When reading ftyp preallocate the memory to hold all the brands

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1963,7 +1963,7 @@ fn read_ftyp<T: Read>(src: &mut BMFFBox<T>) -> Result<FileTypeBox> {
     }
     // Is a brand_count of zero valid?
     let brand_count = bytes_left / 4;
-    let mut brands = TryVec::new();
+    let mut brands = TryVec::with_capacity(brand_count.try_into()?)?;
     for _ in 0..brand_count {
         brands.push(be_u32(src)?.into())?;
     }


### PR DESCRIPTION
This fixes https://oss-fuzz.com/testcase-detail/5637965842481152. We were timing out due to the additional time it takes to do many small allocations.