### PR TITLE
Preallocate vector storage when the size is known

### DIFF
--- a/mp4parse/src/fallible.rs
+++ b/mp4parse/src/fallible.rs
@@ -256,7 +256,7 @@ impl<T> TryVec<T> {
         Ok(())
     }
 
-    fn reserve(&mut self, additional: usize) -> Result<()> {
+    pub fn reserve(&mut self, additional: usize) -> Result<()> {
         #[cfg(feature = "mp4parse_fallible")]
         {
             let available = self

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -43,6 +43,7 @@ use byteorder::WriteBytesExt;
 use num::{CheckedAdd, CheckedSub};
 use num::{PrimInt, Zero};
 use std::convert::TryFrom;
+use std::convert::TryInto;
 
 use std::io::Read;
 use std::ops::Neg;
@@ -1712,13 +1713,14 @@ fn get_pssh_info(
 
     pssh_data.clear();
     for pssh in &context.psshs {
-        let content_len = pssh.box_content.len();
-        if content_len > std::u32::MAX as usize {
-            return Err(Mp4parseStatus::Invalid);
-        }
+        let content_len = pssh
+            .box_content
+            .len()
+            .try_into()
+            .map_err(|_| Mp4parseStatus::Invalid)?;
         let mut data_len = TryVec::new();
         if data_len
-            .write_u32::<byteorder::NativeEndian>(content_len as u32)
+            .write_u32::<byteorder::NativeEndian>(content_len)
             .is_err()
         {
             return Err(Mp4parseStatus::Io);


### PR DESCRIPTION
Similar to https://github.com/mozilla/mp4parse-rust/pull/234, this attempts to avoid performance issues similar to the specific ones we've found in fuzzing tests.