### PR TITLE
Fix bustage from BMO bug 1660551

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -28,7 +28,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
 hashbrown = "0.7.1"
-num-traits = "0.2.0"
+num-traits = "=0.2.10"
 log = "0.4"
 static_assertions = "1.1.0"
 

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 byteorder = "1.2.1"
 log = "0.4"
 mp4parse = {version = "0.11.2", path = "../mp4parse"}
-num = "0.3.0"
+num-traits = "=0.2.10"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -37,11 +37,11 @@
 
 extern crate byteorder;
 extern crate mp4parse;
-extern crate num;
+extern crate num_traits;
 
 use byteorder::WriteBytesExt;
-use num::{CheckedAdd, CheckedSub};
-use num::{PrimInt, Zero};
+use num_traits::{CheckedAdd, CheckedSub};
+use num_traits::{PrimInt, Zero};
 use std::convert::TryFrom;
 use std::convert::TryInto;
 
@@ -704,7 +704,7 @@ where
 
     let integer = numerator / denominator;
     let remainder = numerator % denominator;
-    num::cast(scale2).and_then(|s| match integer.checked_mul(&s) {
+    num_traits::cast(scale2).and_then(|s| match integer.checked_mul(&s) {
         Some(integer) => remainder
             .checked_mul(&s)
             .and_then(|remainder| (remainder / denominator).checked_add(&integer)),


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1660551#c3

This appears related to https://github.com/rust-lang/rust/issues/61002
though, I'm not sure what changed between versions of num-traits to make
this an issue, pinning to the version we were already using seems to
function as a workaround for now.