### PR TITLE
Update hashbrown.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -27,8 +27,8 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-fallible_collections = { version = "0.1.3", features = ["std_io"] }
-hashbrown = "0.7.1"
+fallible_collections = { version = "0.2", features = ["std_io"] }
+hashbrown = "0.9"
 num-traits = "=0.2.10"
 log = "0.4"
 static_assertions = "1.1.0"

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.2.1"
-fallible_collections = { version = "0.1.3", features = ["std_io"] }
+fallible_collections = { version = "0.2", features = ["std_io"] }
 log = "0.4"
 mp4parse = {version = "0.11.2", path = "../mp4parse"}
 num-traits = "=0.2.10"


### PR DESCRIPTION
We have two hashbrown versions in Gecko now. This and
https://github.com/vcombey/fallible_collections/pull/8 allow us to get
rid of it.