### PR TITLE
Add a benchmark for measuring AVIF parsing performance

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -37,3 +37,12 @@ static_assertions = "1.1.0"
 test-assembler = "0.1.2"
 env_logger = "0.7.1"
 walkdir = "2.3.1"
+criterion = "0.3"
+
+[[bench]]
+name = "avif_benchmark"
+harness = false
+
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+[lib]
+bench = false

--- a/mp4parse/benches/avif_benchmark.rs
+++ b/mp4parse/benches/avif_benchmark.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+extern crate criterion;
+extern crate mp4parse as mp4;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::fs::File;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("avif_largest", |b| b.iter(|| avif_largest()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+
+fn avif_largest() {
+    let context = &mut mp4::AvifContext::new();
+    let input = &mut File::open(
+        "av1-avif/testFiles/Netflix/avif/cosmos_frame05000_yuv444_12bpc_bt2020_pq_qlossless.avif",
+    )
+    .expect("Unknown file");
+    assert!(mp4::read_avif(input, context).is_ok());
+}


### PR DESCRIPTION
Run it with `cargo bench`

See https://bheisler.github.io/criterion.rs/book/index.html for more