### PR TITLE
Preallocate storage when parsing iref box and add debugging output

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -27,6 +27,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
+env_logger = "0.7.1"
 fallible_collections = { version = "0.3", features = ["std_io"] }
 hashbrown = "0.9"
 num-traits = "=0.2.10"
@@ -35,7 +36,6 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 test-assembler = "0.1.2"
-env_logger = "0.7.1"
 walkdir = "2.3.1"
 criterion = "0.3"
 

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -663,8 +663,6 @@ fn public_avif_primary_item_is_grid() {
 
 #[test]
 fn public_avif_read_samples() {
-    env_logger::init();
-
     for entry in walkdir::WalkDir::new(AVIF_TEST_DIR) {
         let entry = entry.expect("AVIF entry");
         let path = entry.path();


### PR DESCRIPTION
This fixes a timeout with [the attached testcase](https://github.com/mozilla/mp4parse-rust/files/5539940/clusterfuzz-testcase-avif-5641604844748800.zip) run against the `mp4parse_capi` crate with:
```
cargo +nightly fuzz run avif clusterfuzz-testcase-avif-5641604844748800 -- -timeout=6
```

Resolves https://oss-fuzz.com/testcase-detail/5641604844748800