### PR TITLE
Make parsers return context objects rather that using out params

### DIFF
--- a/mp4parse/benches/avif_benchmark.rs
+++ b/mp4parse/benches/avif_benchmark.rs
@@ -15,10 +15,9 @@ criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
 
 fn avif_largest() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(
         "av1-avif/testFiles/Netflix/avif/cosmos_frame05000_yuv444_12bpc_bt2020_pq_qlossless.avif",
     )
     .expect("Unknown file");
-    assert!(mp4::read_avif(input, context).is_ok());
+    assert!(mp4::read_avif(input).is_ok());
 }

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -7,7 +7,6 @@
 
 use super::read_mp4;
 use super::Error;
-use super::MediaContext;
 use fallible_collections::TryRead as _;
 
 use std::convert::TryInto as _;
@@ -195,8 +194,7 @@ fn read_truncated_ftyp() {
             .B32(0) // minor version
             .append_bytes(b"isom")
     });
-    let mut context = MediaContext::new();
-    match read_mp4(&mut stream, &mut context) {
+    match read_mp4(&mut stream) {
         Err(Error::UnexpectedEOF) => (),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -346,7 +344,7 @@ fn read_mdhd_invalid_timescale() {
     assert_eq!(stream.head.name, BoxType::MediaHeaderBox);
     assert_eq!(stream.head.size, 44);
     let r = super::parse_mdhd(&mut stream, &mut super::Track::new(0));
-    assert_eq!(r.is_err(), true);
+    assert!(r.is_err());
 }
 
 #[test]
@@ -387,7 +385,7 @@ fn read_mvhd_invalid_timescale() {
     assert_eq!(stream.head.name, BoxType::MovieHeaderBox);
     assert_eq!(stream.head.size, 120);
     let r = super::parse_mvhd(&mut stream);
-    assert_eq!(r.is_err(), true);
+    assert!(r.is_err());
 }
 
 #[test]
@@ -1249,9 +1247,8 @@ fn read_invalid_pssh() {
     let mut stream = make_box(BoxSize::Auto, b"moov", |s| s.append_bytes(pssh.as_slice()));
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let mut context = super::MediaContext::new();
 
-    match super::read_moov(&mut stream, &mut context) {
+    match super::read_moov(&mut stream) {
         Err(Error::InvalidData(s)) => assert_eq!(s, "read_buf size exceeds BUF_SIZE_LIMIT"),
         _ => panic!("unexpected result with invalid descriptor"),
     }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -43,8 +43,7 @@ fn public_api() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     assert_eq!(context.timescale, Some(mp4::MediaTimeScale(1000)));
     for track in context.tracks {
         match track.track_type {
@@ -164,8 +163,7 @@ fn public_metadata() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     let udta = context
         .userdata
         .expect("didn't find udta")
@@ -232,8 +230,7 @@ fn public_metadata_gnre() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     let udta = context
         .userdata
         .expect("didn't find udta")
@@ -301,8 +298,7 @@ fn public_audio_tenc() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -360,8 +356,7 @@ fn public_video_cenc() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -433,8 +428,7 @@ fn public_audio_cbcs() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         assert_eq!(stsd.descriptions.len(), 2);
@@ -516,8 +510,7 @@ fn public_video_cbcs() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         assert_eq!(stsd.descriptions.len(), 2);
@@ -576,8 +569,7 @@ fn public_video_av1() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let mut context = mp4::MediaContext::new();
-    mp4::read_mp4(&mut c, &mut context).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
     for track in context.tracks {
         // track part
         assert_eq!(track.duration, Some(mp4::TrackScaledTime(512, 0)));
@@ -623,41 +615,36 @@ fn public_video_av1() {
 
 #[test]
 fn public_avif_primary_item() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(IMAGE_AVIF).expect("Unknown file");
-    mp4::read_avif(input, context).expect("read_avif failed");
+    let context = mp4::read_avif(input).expect("read_avif failed");
     assert_eq!(context.primary_item.len(), 6979);
     assert_eq!(context.primary_item[0..4], [0x12, 0x00, 0x0a, 0x0a]);
 }
 
 #[test]
 fn public_avif_primary_item_split_extents() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(IMAGE_AVIF_EXTENTS).expect("Unknown file");
-    mp4::read_avif(input, context).expect("read_avif failed");
+    let context = mp4::read_avif(input).expect("read_avif failed");
     assert_eq!(context.primary_item.len(), 4387);
 }
 
 #[test]
 fn public_avif_bug_1655846() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(IMAGE_AVIF_CORRUPT).expect("Unknown file");
-    assert!(mp4::read_avif(input, context).is_err());
+    assert!(mp4::read_avif(input).is_err());
 }
 
 #[test]
 fn public_avif_bug_1661347() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(IMAGE_AVIF_CORRUPT_2).expect("Unknown file");
-    assert!(mp4::read_avif(input, context).is_err());
+    assert!(mp4::read_avif(input).is_err());
 }
 
 #[test]
 #[ignore] // Remove when we add support; see https://github.com/mozilla/mp4parse-rust/issues/198
 fn public_avif_primary_item_is_grid() {
-    let context = &mut mp4::AvifContext::new();
     let input = &mut File::open(IMAGE_AVIF_GRID).expect("Unknown file");
-    mp4::read_avif(input, context).expect("read_avif failed");
+    mp4::read_avif(input).expect("read_avif failed");
     // Add some additional checks
 }
 
@@ -675,8 +662,7 @@ fn public_avif_read_samples() {
             continue; // Remove when public_avif_primary_item_is_grid passes
         }
         println!("parsing {:?}", path);
-        let context = &mut mp4::AvifContext::new();
         let input = &mut File::open(path).expect("Unknow file");
-        mp4::read_avif(input, context).expect("read_avif failed");
+        mp4::read_avif(input).expect("read_avif failed");
     }
 }


### PR DESCRIPTION
This simplifies the caller by eliminating the need to create the context, ensures that an empty/invalid context doesn't exist to accidentally operate on, and makes the code more idiomatic rust.

Also, make some other minor cleanups.