### PR TITLE
Avoid unnecessary copies of AVIF primary_item and alpha_item

### DIFF
--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -32,7 +32,8 @@ static IMAGE_AVIF_EXTENTS: &str = "tests/kodim-extents.avif";
 static IMAGE_AVIF_CORRUPT: &str = "tests/bug-1655846.avif";
 static IMAGE_AVIF_CORRUPT_2: &str = "tests/bug-1661347.avif";
 static IMAGE_AVIF_GRID: &str = "av1-avif/testFiles/Microsoft/Summer_in_Tomsk_720p_5x4_grid.avif";
-static AVIF_TEST_DIR: &str = "av1-avif/testFiles";
+static AVIF_TEST_DIRS: &[&str] = &["tests", "av1-avif/testFiles"];
+static AVIF_CORRUPT_IMAGES: &[&str] = &[IMAGE_AVIF_CORRUPT, IMAGE_AVIF_CORRUPT_2];
 
 // Adapted from https://github.com/GuillaumeGomez/audio-video-metadata/blob/9dff40f565af71d5502e03a2e78ae63df95cfd40/src/metadata.rs#L53
 #[test]
@@ -617,15 +618,15 @@ fn public_video_av1() {
 fn public_avif_primary_item() {
     let input = &mut File::open(IMAGE_AVIF).expect("Unknown file");
     let context = mp4::read_avif(input).expect("read_avif failed");
-    assert_eq!(context.primary_item.len(), 6979);
-    assert_eq!(context.primary_item[0..4], [0x12, 0x00, 0x0a, 0x0a]);
+    assert_eq!(context.primary_item().len(), 6979);
+    assert_eq!(context.primary_item()[0..4], [0x12, 0x00, 0x0a, 0x0a]);
 }
 
 #[test]
 fn public_avif_primary_item_split_extents() {
     let input = &mut File::open(IMAGE_AVIF_EXTENTS).expect("Unknown file");
     let context = mp4::read_avif(input).expect("read_avif failed");
-    assert_eq!(context.primary_item.len(), 4387);
+    assert_eq!(context.primary_item().len(), 4387);
 }
 
 #[test]
@@ -650,19 +651,25 @@ fn public_avif_primary_item_is_grid() {
 
 #[test]
 fn public_avif_read_samples() {
-    for entry in walkdir::WalkDir::new(AVIF_TEST_DIR) {
-        let entry = entry.expect("AVIF entry");
-        let path = entry.path();
-        if !path.is_file() || path.extension().unwrap_or_default() != "avif" {
-            eprintln!("Skipping {:?}", path);
-            continue; // Skip directories, ReadMe.txt, etc.
+    for dir in AVIF_TEST_DIRS {
+        for entry in walkdir::WalkDir::new(dir) {
+            let entry = entry.expect("AVIF entry");
+            let path = entry.path();
+            if !path.is_file() || path.extension().unwrap_or_default() != "avif" {
+                eprintln!("Skipping {:?}", path);
+                continue; // Skip directories, ReadMe.txt, etc.
+            }
+            if AVIF_CORRUPT_IMAGES.contains(&path.to_str().unwrap()) {
+                eprintln!("Skipping {:?}", path);
+                continue;
+            }
+            if path == Path::new(IMAGE_AVIF_GRID) {
+                eprintln!("Skipping {:?}", path);
+                continue; // Remove when public_avif_primary_item_is_grid passes
+            }
+            println!("parsing {:?}", path);
+            let input = &mut File::open(path).expect("Unknow file");
+            mp4::read_avif(input).expect("read_avif failed");
         }
-        if path == Path::new(IMAGE_AVIF_GRID) {
-            eprintln!("Skipping {:?}", path);
-            continue; // Remove when public_avif_primary_item_is_grid passes
-        }
-        println!("parsing {:?}", path);
-        let input = &mut File::open(path).expect("Unknow file");
-        mp4::read_avif(input).expect("read_avif failed");
     }
 }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -659,7 +659,13 @@ fn public_avif_read_samples() {
                 eprintln!("Skipping {:?}", path);
                 continue; // Skip directories, ReadMe.txt, etc.
             }
-            if AVIF_CORRUPT_IMAGES.contains(&path.to_str().unwrap()) {
+            if AVIF_CORRUPT_IMAGES
+                .iter()
+                .find(|&&corrupt| {
+                    std::fs::canonicalize(corrupt).unwrap() == path.canonicalize().unwrap()
+                })
+                .is_some()
+            {
                 eprintln!("Skipping {:?}", path);
                 continue;
             }

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.2.1"
-fallible_collections = { version = "0.2", features = ["std_io"] }
+fallible_collections = { version = "0.3", features = ["std_io"] }
 log = "0.4"
 mp4parse = {version = "0.11.2", path = "../mp4parse"}
 num-traits = "=0.2.10"

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -475,7 +475,6 @@ impl ContextParser for Mp4parseParser {
     }
 }
 
-#[derive(Default)]
 pub struct Mp4parseAvifParser {
     context: AvifContext,
 }
@@ -1197,8 +1196,7 @@ pub unsafe extern "C" fn mp4parse_avif_get_primary_item(
 
     let context = (*parser).context();
 
-    // TODO: check for a valid parsed context. See https://github.com/mozilla/mp4parse-rust/issues/195
-    (*primary_item).set_data(&context.primary_item);
+    (*primary_item).set_data(context.primary_item());
 
     Mp4parseStatus::Ok
 }


### PR DESCRIPTION
When they're already contiguously present in an `mdat` buffer (even the same one), `AvifContext::primary_item()` and `::alpha_item()` can return slices rather than having to copy the (potentially large) buffers.

This results in a measured performance increase of ~50% for parsing a 4.7 MB AVIF (the largest in our test set):

```
$ git checkout master
$ cargo bench -- --save-baseline base
avif_largest            time:   [2.0990 ms 2.1352 ms 2.1727 ms]
```
```
$ git checkout avif-nocopy
$ cargo bench -- --save-baseline avif-nocopy
$ cargo bench -- --load-baseline avif-nocopy --baseline base
avif_largest            time:   [1.0077 ms 1.0257 ms 1.0449 ms]
                        change: [-52.649% -51.371% -50.022%] (p = 0.00 < 0.05)
                        Performance has improved.
```
Also, clean up some related code add add tests.