### PR TITLE
Check for overflow when calculating ipma index

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2039,7 +2039,7 @@ fn read_ipma<T: Read>(
 fn read_ipco<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<u16, ItemProperty>> {
     let mut properties = TryHashMap::with_capacity(1)?;
 
-    let mut index = 1; // ipma uses 1-based indexing
+    let mut index: u16 = 1; // ipma uses 1-based indexing
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         if let Some(property) = match b.head.name {
@@ -2053,7 +2053,9 @@ fn read_ipco<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<u16, ItemProper
             properties.insert(index, property)?;
         }
 
-        index += 1; // must include ignored properties to have correct indexes
+        index = index
+            .checked_add(1) // must include ignored properties to have correct indexes
+            .ok_or(Error::InvalidData("ipco index overflow"))?;
 
         check_parser_state!(b.content);
     }


### PR DESCRIPTION
Resolves https://oss-fuzz.com/testcase-detail/5990897275764736

This fixes an assert with the [attached testcase](https://github.com/mozilla/mp4parse-rust/files/5647901/clusterfuzz-testcase-minimized-avif-5990897275764736.zip) run against the mp4parse_capi crate with:

```
cargo +nightly fuzz run avif testcase-minimized-avif-5990897275764736 -- -timeout=6
```