### PR TITLE
Add an API exposing alpha_item and premultiplied_alpha

### DIFF
--- a/mp4parse_capi/fuzz/fuzz_targets/avif.rs
+++ b/mp4parse_capi/fuzz/fuzz_targets/avif.rs
@@ -29,12 +29,8 @@ fuzz_target!(|data: &[u8]| {
             return;
         }
 
-        let mut primary_item = Default::default();
-        mp4parse_avif_get_primary_item(context, &mut primary_item);
-
-        let mut alpha_item = Default::default();
-        let mut premultiplied_alpha = Default::default();
-        mp4parse_avif_get_alpha_item(context, &mut alpha_item, &mut premultiplied_alpha);
+        let mut avif_image = Default::default();
+        mp4parse_avif_get_image(context, &mut avif_image);
 
         mp4parse_avif_free(context);
     }

--- a/mp4parse_capi/fuzz/fuzz_targets/avif.rs
+++ b/mp4parse_capi/fuzz/fuzz_targets/avif.rs
@@ -32,6 +32,10 @@ fuzz_target!(|data: &[u8]| {
         let mut primary_item = Default::default();
         mp4parse_avif_get_primary_item(context, &mut primary_item);
 
+        let mut alpha_item = Default::default();
+        let mut premultiplied_alpha = Default::default();
+        mp4parse_avif_get_alpha_item(context, &mut alpha_item, &mut premultiplied_alpha);
+
         mp4parse_avif_free(context);
     }
 });

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1189,8 +1189,8 @@ fn mp4parse_get_track_video_info_safe(
 /// pointer points to a valid `Mp4parseAvifParser`, and that the avif_image
 /// pointer points to a valid `AvifImage`. If there was not a previous
 /// successful call to `mp4parse_avif_read()`, no guarantees are made as to
-/// the state of `avif_image`. If `avif_image.alpha_item` are set with a
-/// positive`length` and non-null `data`, then the `avif_image` contains an
+/// the state of `avif_image`. If `avif_image.alpha_item` is set to a
+/// positive `length` and non-null `data`, then the `avif_image` contains an
 /// valid alpha channel data. Otherwise, the image is opaque.
 #[no_mangle]
 pub unsafe extern "C" fn mp4parse_avif_get_image(
@@ -1203,14 +1203,12 @@ pub unsafe extern "C" fn mp4parse_avif_get_image(
 
     // Initialize fields to default values to ensure all fields are always valid.
     *avif_image = Default::default();
-    let image_ref = &mut (*avif_image);
-
     let context = (*parser).context();
 
-    image_ref.primary_item.set_data(context.primary_item());
+    (*avif_image).primary_item.set_data(context.primary_item());
     if let Some(context_alpha_item) = context.alpha_item() {
-        image_ref.alpha_item.set_data(context_alpha_item);
-        image_ref.premultiplied_alpha = context.premultiplied_alpha;
+        (*avif_image).alpha_item.set_data(context_alpha_item);
+        (*avif_image).premultiplied_alpha = context.premultiplied_alpha;
     }
 
     Mp4parseStatus::Ok

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1201,6 +1201,28 @@ pub unsafe extern "C" fn mp4parse_avif_get_primary_item(
     Mp4parseStatus::Ok
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn mp4parse_avif_get_alpha_item(
+    parser: *mut Mp4parseAvifParser,
+    alpha_item: *mut Mp4parseByteData,
+    premultiplied_alpha: *mut bool,
+) -> Mp4parseStatus {
+    if parser.is_null() {
+        return Mp4parseStatus::BadArg;
+    }
+
+    *alpha_item = Default::default();
+
+    let context = (*parser).context();
+    if let Some(context_alpha_item) = context.alpha_item() {
+        (*alpha_item).set_data(context_alpha_item);
+        *premultiplied_alpha = context.premultiplied_alpha;
+        Mp4parseStatus::Ok
+    } else {
+        Mp4parseStatus::Invalid
+    }
+}
+
 /// Fill the supplied `Mp4parseByteData` with index information from `track`.
 ///
 /// # Safety


### PR DESCRIPTION
Create an API to expose the `alpha_item` and `premultiplied_alpha` with `Mp4parseAvifParser`. This helps to add the alpha support in [BMO1654462](https://bugzilla.mozilla.org/show_bug.cgi?id=1654462)