### PR TITLE
Bump env_logger and num-traits

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -27,10 +27,10 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-env_logger = "0.7.1"
+env_logger = "0.8"
 fallible_collections = { version = "0.3", features = ["std_io"] }
 hashbrown = "0.9"
-num-traits = "=0.2.10"
+num-traits = "0.2.14"
 log = "0.4"
 static_assertions = "1.1.0"
 

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -27,7 +27,7 @@ byteorder = "1.2.1"
 fallible_collections = { version = "0.3", features = ["std_io"] }
 log = "0.4"
 mp4parse = {version = "0.11.2", path = "../mp4parse"}
-num-traits = "=0.2.10"
+num-traits = "0.2.14"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.8"


### PR DESCRIPTION
The latter is required by https://github.com/image-rs/image/pull/1398