### PR TITLE
Add support for MPEG-2 layer 3 codec ID

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -3346,9 +3346,14 @@ fn read_dc_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 
     esds.audio_codec = match object_profile {
         0x40 | 0x41 => CodecType::AAC,
-        0x6B => CodecType::MP3,
+        0x69 | 0x6B => CodecType::MP3,
         _ => CodecType::Unknown,
     };
+
+    debug!(
+        "read_dc_descriptor: esds.audio_codec = {:?}",
+        esds.audio_codec
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Resolves https://github.com/mozilla/mp4parse-rust/issues/274

See also https://bugzilla.mozilla.org/show_bug.cgi?id=986926. When we update mp4parse_capi in mozilla-central, we're going to have to address [one issue from a previous commit](https://github.com/mozilla/mp4parse-rust/pull/245#issuecomment-778692532), but that should be straightforward, I think.