### PR TITLE
Allow optional attributes on entries in the box_database macro

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -14,10 +14,10 @@ struct HashMap;
 struct String;
 
 macro_rules! box_database {
-    ($($boxenum:ident $boxtype:expr),*,) => {
+    ($($(#[$attr:meta])* $boxenum:ident $boxtype:expr),*,) => {
         #[derive(Clone, Copy, PartialEq)]
         pub enum BoxType {
-            $($boxenum),*,
+            $($(#[$attr])* $boxenum),*,
             UnknownBox(u32),
         }
 
@@ -25,7 +25,7 @@ macro_rules! box_database {
             fn from(t: u32) -> BoxType {
                 use self::BoxType::*;
                 match t {
-                    $($boxtype => $boxenum),*,
+                    $($(#[$attr])* $boxtype => $boxenum),*,
                     _ => UnknownBox(t),
                 }
             }
@@ -35,18 +35,19 @@ macro_rules! box_database {
             fn into(self) -> u32 {
                 use self::BoxType::*;
                 match self {
-                    $($boxenum => $boxtype),*,
+                    $($(#[$attr])* $boxenum => $boxtype),*,
                     UnknownBox(t) => t,
                 }
             }
         }
 
-        impl fmt::Debug for BoxType {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                let fourcc: FourCC = From::from(self.clone());
-                fourcc.fmt(f)
-            }
-        }
+    }
+}
+
+impl fmt::Debug for BoxType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let fourcc: FourCC = From::from(self.clone());
+        fourcc.fmt(f)
     }
 }
 


### PR DESCRIPTION
This is useful for making entries feature gated like so:

```rust
box_database!(
    // …
    MP4VideoSampleEntry               0x6d70_3476, // "mp4v"
    #[cfg(feature = "3gpp")]
    AMRNBSampleEntry                  0x7361_6d72, // "samr" - AMR narrow-band
    // …
);
```

Also, move the `fmt::Debug` impl for `BoxType` outside the macro, since it doesn't depend on any of the macro parameters.