### PR TITLE
Add clippy to build action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,15 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt
+      run: rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt clippy
 
     - name: Check format
       shell: bash
       run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
+
+    - name: Clippy
+      shell: bash
+      run: rustup run ${{ matrix.rust }} cargo clippy --all -- -D warnings
 
     - name: Test (release)
       shell: bash

--- a/mp4parse/benches/avif_benchmark.rs
+++ b/mp4parse/benches/avif_benchmark.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs::File;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("avif_largest", |b| b.iter(|| avif_largest()));
+    c.bench_function("avif_largest", |b| b.iter(avif_largest));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -31,10 +31,10 @@ macro_rules! box_database {
             }
         }
 
-        impl Into<u32> for BoxType {
-            fn into(self) -> u32 {
+        impl From<BoxType> for u32 {
+            fn from(b: BoxType) -> u32 {
                 use self::BoxType::*;
-                match self {
+                match b {
                     $($(#[$attr])* $boxenum => $boxtype),*,
                     UnknownBox(t) => t,
                 }
@@ -46,7 +46,7 @@ macro_rules! box_database {
 
 impl fmt::Debug for BoxType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let fourcc: FourCC = From::from(self.clone());
+        let fourcc: FourCC = From::from(*self);
         fourcc.fmt(f)
     }
 }

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -4,6 +4,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// `clippy::upper_case_acronyms` is a nightly-only lint as of 2021-03-15, so we
+// allow `clippy::unknown_clippy_lints` to ignore it on stable - but
+// `clippy::unknown_clippy_lints` has been renamed in nightly, so we need to
+// allow `renamed_and_removed_lints` to ignore a warning for that.
+#![allow(renamed_and_removed_lints)]
+#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::upper_case_acronyms)]
+
 #[macro_use]
 extern crate log;
 
@@ -41,6 +49,8 @@ const TABLE_SIZE_LIMIT: u32 = 30 * 60 * 60 * 24 * 7;
 /// A trait to indicate a type can be infallibly converted to `u64`.
 /// This should only be implemented for infallible conversions, so only unsigned types are valid.
 trait ToU64 {
+    // Remove when https://github.com/rust-lang/rust-clippy/issues/6727 is resolved
+    #[allow(clippy::wrong_self_convention)]
     fn to_u64(self) -> u64;
 }
 
@@ -59,6 +69,8 @@ impl ToU64 for usize {
 /// A trait to indicate a type can be infallibly converted to `usize`.
 /// This should only be implemented for infallible conversions, so only unsigned types are valid.
 pub trait ToUsize {
+    // Remove when https://github.com/rust-lang/rust-clippy/issues/6727 is resolved
+    #[allow(clippy::wrong_self_convention)]
     fn to_usize(self) -> usize;
 }
 
@@ -803,7 +815,7 @@ impl AvifContext {
                     "AvifItem::Location requires the location exists in AvifContext::item_storage"
                 );
             }
-            AvifItem::Data(data) => return data.as_slice(),
+            AvifItem::Data(data) => data.as_slice(),
         }
     }
 }
@@ -1923,8 +1935,8 @@ impl std::ops::Add<U32MulU16> for U32MulU8 {
 
     fn add(self, rhs: U32MulU16) -> Self::Output {
         static_assertions::const_assert!(U32MulU8::MAX + U32MulU16::MAX < U64::MAX);
-        let lhs: u64 = self.get().into();
-        let rhs: u64 = rhs.get().into();
+        let lhs: u64 = self.get();
+        let rhs: u64 = rhs.get();
         Self::Output::new(lhs.checked_add(rhs).expect("infallible"))
     }
 }
@@ -2003,6 +2015,7 @@ fn read_ipma<T: Read>(
         };
 
         if let Some(previous_association) = associations.last() {
+            #[allow(clippy::comparison_chain)]
             if previous_association.item_id > item_id {
                 return Err(Error::InvalidData(
                     "Each ItemPropertyAssociation box shall be ordered by increasing item_ID",
@@ -2088,7 +2101,7 @@ fn read_pixi<T: Read>(src: &mut BMFFBox<T>) -> Result<TryVec<u8>> {
     let mut channels = TryVec::with_capacity(num_channels)?;
     let num_channels_read = src.try_read_to_end(&mut channels)?;
 
-    if num_channels_read != num_channels.into() {
+    if num_channels_read != num_channels {
         return Err(Error::InvalidData("invalid num_channels"));
     }
 
@@ -3711,7 +3724,7 @@ fn read_qt_wave_atom<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
         }
     }
 
-    codec_specific.ok_or_else(|| Error::InvalidData("malformed audio sample entry"))
+    codec_specific.ok_or(Error::InvalidData("malformed audio sample entry"))
 }
 
 /// Parse an audio description inside an stsd box.

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -998,14 +998,10 @@ fn get_track_audio_info(
                 sample_info.protected_data.is_encrypted = tenc.is_encrypted;
                 sample_info.protected_data.iv_size = tenc.iv_size;
                 sample_info.protected_data.kid.set_data(&(tenc.kid));
-                sample_info.protected_data.crypt_byte_block = match tenc.crypt_byte_block_count {
-                    Some(n) => n,
-                    None => 0,
-                };
-                sample_info.protected_data.skip_byte_block = match tenc.skip_byte_block_count {
-                    Some(n) => n,
-                    None => 0,
-                };
+                sample_info.protected_data.crypt_byte_block =
+                    tenc.crypt_byte_block_count.unwrap_or(0);
+                sample_info.protected_data.skip_byte_block =
+                    tenc.skip_byte_block_count.unwrap_or(0);
                 if let Some(ref iv_vec) = tenc.constant_iv {
                     if iv_vec.len() > std::u32::MAX as usize {
                         return Err(Mp4parseStatus::Invalid);
@@ -1164,14 +1160,10 @@ fn mp4parse_get_track_video_info_safe(
                 sample_info.protected_data.is_encrypted = tenc.is_encrypted;
                 sample_info.protected_data.iv_size = tenc.iv_size;
                 sample_info.protected_data.kid.set_data(&(tenc.kid));
-                sample_info.protected_data.crypt_byte_block = match tenc.crypt_byte_block_count {
-                    Some(n) => n,
-                    None => 0,
-                };
-                sample_info.protected_data.skip_byte_block = match tenc.skip_byte_block_count {
-                    Some(n) => n,
-                    None => 0,
-                };
+                sample_info.protected_data.crypt_byte_block =
+                    tenc.crypt_byte_block_count.unwrap_or(0);
+                sample_info.protected_data.skip_byte_block =
+                    tenc.skip_byte_block_count.unwrap_or(0);
                 if let Some(ref iv_vec) = tenc.constant_iv {
                     if iv_vec.len() > std::u32::MAX as usize {
                         return Err(Mp4parseStatus::Invalid);
@@ -1514,10 +1506,7 @@ fn create_sample_table(
     };
 
     // According to spec, no sync table means every sample is sync sample.
-    let has_sync_table = match track.stss {
-        Some(_) => true,
-        _ => false,
-    };
+    let has_sync_table = matches!(track.stss, Some(_));
 
     let mut sample_size_iter = stsz.sample_sizes.iter();
 
@@ -1575,10 +1564,7 @@ fn create_sample_table(
         }
     }
 
-    let ctts_iter = match track.ctts {
-        Some(ref v) => Some(v.samples.as_slice().iter()),
-        _ => None,
-    };
+    let ctts_iter = track.ctts.as_ref().map(|v| v.samples.as_slice().iter());
 
     let mut ctts_offset_iter = TimeOffsetIterator {
         cur_sample_range: (0..0),


### PR DESCRIPTION
Inspired by https://github.com/mozilla/mp4parse-rust/pull/186, updated for GitHub Actions.

Running a separate step for nightly clippy is annoying, but non-nightly builds don't recognize `clippy::upper_case_acronyms` and as far as I understand it's not currently possible to disable lints via Cargo.toml or clippy.toml.