### PR TITLE
clippy: Rename OptionalFourCC -> OptionalFourCc

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -328,12 +328,12 @@ pub struct Mp4parsePsshInfo {
 
 #[repr(u8)]
 #[derive(Debug, PartialEq)]
-pub enum OptionalFourCC {
+pub enum OptionalFourCc {
     None,
     Some([u8; 4]),
 }
 
-impl Default for OptionalFourCC {
+impl Default for OptionalFourCc {
     fn default() -> Self {
         Self::None
     }
@@ -342,7 +342,7 @@ impl Default for OptionalFourCC {
 #[repr(C)]
 #[derive(Default, Debug)]
 pub struct Mp4parseSinfInfo {
-    pub original_format: OptionalFourCC,
+    pub original_format: OptionalFourCc,
     pub scheme_type: Mp4ParseEncryptionSchemeType,
     pub is_encrypted: u8,
     pub iv_size: u8,
@@ -980,7 +980,7 @@ fn get_track_audio_info(
             .find(|sinf| sinf.tenc.is_some())
         {
             sample_info.protected_data.original_format =
-                OptionalFourCC::Some(p.original_format.value);
+                OptionalFourCc::Some(p.original_format.value);
             sample_info.protected_data.scheme_type = match p.scheme_type {
                 Some(ref scheme_type_box) => {
                     match scheme_type_box.scheme_type.value.as_ref() {
@@ -1142,7 +1142,7 @@ fn mp4parse_get_track_video_info_safe(
             .find(|sinf| sinf.tenc.is_some())
         {
             sample_info.protected_data.original_format =
-                OptionalFourCC::Some(p.original_format.value);
+                OptionalFourCc::Some(p.original_format.value);
             sample_info.protected_data.scheme_type = match p.scheme_type {
                 Some(ref scheme_type_box) => {
                     match scheme_type_box.scheme_type.value.as_ref() {

--- a/mp4parse_capi/tests/test_encryption.rs
+++ b/mp4parse_capi/tests/test_encryption.rs
@@ -52,7 +52,7 @@ fn parse_cenc() {
         let protected_data = &(*video.sample_info).protected_data;
         assert_eq!(
             protected_data.original_format,
-            OptionalFourCC::Some(*b"avc1")
+            OptionalFourCc::Some(*b"avc1")
         );
         assert_eq!(
             protected_data.scheme_type,
@@ -84,7 +84,7 @@ fn parse_cenc() {
         let protected_data = &(*audio.sample_info).protected_data;
         assert_eq!(
             protected_data.original_format,
-            OptionalFourCC::Some(*b"mp4a")
+            OptionalFourCc::Some(*b"mp4a")
         );
         assert_eq!(protected_data.is_encrypted, 0x01);
         assert_eq!(protected_data.iv_size, 16);
@@ -137,7 +137,7 @@ fn parse_cbcs() {
         let protected_data = &(*video.sample_info).protected_data;
         assert_eq!(
             protected_data.original_format,
-            OptionalFourCC::Some(*b"avc1")
+            OptionalFourCc::Some(*b"avc1")
         );
         assert_eq!(
             protected_data.scheme_type,
@@ -197,7 +197,7 @@ fn parse_unencrypted() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(audio.sample_info_count, 1);
         let protected_data = &(*audio.sample_info).protected_data;
-        assert_eq!(protected_data.original_format, OptionalFourCC::None);
+        assert_eq!(protected_data.original_format, OptionalFourCc::None);
         assert_eq!(
             protected_data.scheme_type,
             Mp4ParseEncryptionSchemeType::None
@@ -266,7 +266,7 @@ fn parse_encrypted_av1() {
         let protected_data = &(*video.sample_info).protected_data;
         assert_eq!(
             protected_data.original_format,
-            OptionalFourCC::Some(*b"av01")
+            OptionalFourCc::Some(*b"av01")
         );
         assert_eq!(
             protected_data.scheme_type,


### PR DESCRIPTION
This fixes the following warning:

warning: name `OptionalFourCC` contains a capitalized acronym
   --> mp4parse_capi/src/lib.rs:331:10
    |
331 | pub enum OptionalFourCC {
    |          ^^^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `OptionalFourCc`
    |
    = note: `#[warn(clippy::upper_case_acronyms)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms