### PR TITLE
Add support for XML metadata box

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -42,6 +42,7 @@ criterion = "0.3"
 
 [features]
 3gpp = []
+meta-xml = []
 
 [[bench]]
 name = "avif_benchmark"

--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -176,6 +176,8 @@ box_database!(
     MetadataItemListEntry             0x696c_7374, // "ilst"
     MetadataItemDataEntry             0x6461_7461, // "data"
     MetadataItemNameBox               0x6e61_6d65, // "name"
+    MetadataXMLBox                    0x786d_6c20, // "xml "
+    MetadataBXMLBox                   0x6278_6d6c, // "bxml"
     UserdataBox                       0x7564_7461, // "udta"
     AlbumEntry                        0xa961_6c62, // "©alb"
     ArtistEntry                       0xa941_5254, // "©ART"

--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -176,7 +176,9 @@ box_database!(
     MetadataItemListEntry             0x696c_7374, // "ilst"
     MetadataItemDataEntry             0x6461_7461, // "data"
     MetadataItemNameBox               0x6e61_6d65, // "name"
+    #[cfg(feature = "meta-xml")]
     MetadataXMLBox                    0x786d_6c20, // "xml "
+    #[cfg(feature = "meta-xml")]
     MetadataBXMLBox                   0x6278_6d6c, // "bxml"
     UserdataBox                       0x7564_7461, // "udta"
     AlbumEntry                        0xa961_6c62, // "©alb"

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2362,7 +2362,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: Option<MediaContext>) -> Resu
         mut mvex,
         mut psshs,
         mut userdata,
-        mut metadata,
+        metadata,
     } = context.unwrap_or_default();
 
     let mut iter = f.box_iter();

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -776,6 +776,7 @@ pub struct MediaContext {
     pub mvex: Option<MovieExtendsBox>,
     pub psshs: TryVec<ProtectionSystemSpecificHeaderBox>,
     pub userdata: Option<Result<UserdataBox>>,
+    #[cfg(feature = "meta-xml")]
     pub metadata: Option<Result<MetadataBox>>,
 }
 
@@ -2321,6 +2322,7 @@ pub fn read_mp4<T: Read>(f: &mut T) -> Result<MediaContext> {
             BoxType::MovieBox => {
                 context = Some(read_moov(&mut b, context)?);
             }
+            #[cfg(feature = "meta-xml")]
             BoxType::MetadataBox => {
                 if let Some(ctx) = &mut context {
                     ctx.metadata = Some(read_meta(&mut b));
@@ -2371,6 +2373,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: Option<MediaContext>) -> Resu
         mut mvex,
         mut psshs,
         mut userdata,
+        #[cfg(feature = "meta-xml")]
         metadata,
     } = context.unwrap_or_default();
 
@@ -2414,6 +2417,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: Option<MediaContext>) -> Resu
         mvex,
         psshs,
         userdata,
+        #[cfg(feature = "meta-xml")]
         metadata,
     })
 }

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -35,3 +35,4 @@ env_logger = "0.8"
 
 [features]
 3gpp = ["mp4parse/3gpp"]
+meta-xml = ["mp4parse/meta-xml"]

--- a/mp4parse_capi/cbindgen.toml
+++ b/mp4parse_capi/cbindgen.toml
@@ -18,3 +18,4 @@ rename_variants = "QualifiedScreamingSnakeCase"
 
 [defines]
 "feature = 3gpp" = "MP4PARSE_FEATURE_3GPP"
+"feature = meta-xml" = "MP4PARSE_FEATURE_META_XML"


### PR DESCRIPTION
This PR adds support for XML and Binary XML metadata boxes. 
They can be found for example in files coming from Sony cameras. 

Sample file here: https://drive.google.com/file/d/1EpOzytKGmx7YyKdmZW1_8b4pMHCVNGrs/view?usp=sharing