### PR TITLE
Run CI every day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 10 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This should make our standard GitHub Actions CI run every day at 10am UTC (as well as on pushes and PRs).

Inspired by https://www.jeffgeerling.com/blog/2020/running-github-actions-workflow-on-schedule-and-other-events