### PR TITLE
Make `create_sample_table` public

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1491,7 +1491,7 @@ impl<'a> SampleToChunkIterator<'a> {
 }
 
 #[allow(clippy::reversed_empty_ranges)]
-fn create_sample_table(
+pub fn create_sample_table(
     track: &Track,
     track_offset_time: CheckedInteger<i64>,
 ) -> Option<TryVec<Mp4parseIndice>> {


### PR DESCRIPTION
This PR makes the `create_sample_table` function in `mp4parse_capi` public. It is needed to get the raw track data and looks like currently it's not possible to do it from Rust.

I tried to refactor both `mp4parse` and `mp4parse_capi` to move these functions to `mp4parse` crate, and leave `mp4parse_capi` as a thin C wrapper only (as mentioned in #133), but I've ran into issues with exposing structs and enums from `mp4parse` crate to cbindgen, so looks like it needs bigger refactoring than just moving functions around.

