### PR TITLE
Change Mp4parseByteData.length to usize, eliminating unsafe casts

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1052,7 +1052,7 @@ enum IlocFieldSize {
 }
 
 impl IlocFieldSize {
-    fn to_bits(&self) -> u8 {
+    fn as_bits(&self) -> u8 {
         match self {
             IlocFieldSize::Zero => 0,
             IlocFieldSize::Four => 32,
@@ -2454,7 +2454,7 @@ fn read_iloc<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<u32, ItemLocati
             ));
         }
 
-        let base_offset = iloc.read_u64(base_offset_size.to_bits())?;
+        let base_offset = iloc.read_u64(base_offset_size.as_bits())?;
         let extent_count = iloc.read_u16(16)?;
 
         if extent_count < 1 {
@@ -2481,7 +2481,7 @@ fn read_iloc<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<u32, ItemLocati
                 None | Some(IlocFieldSize::Zero) => None,
                 Some(index_size) => {
                     debug_assert!(version == IlocVersion::One || version == IlocVersion::Two);
-                    Some(iloc.read_u64(index_size.to_bits())?)
+                    Some(iloc.read_u64(index_size.as_bits())?)
                 }
             };
 
@@ -2489,8 +2489,8 @@ fn read_iloc<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<u32, ItemLocati
             // "If the offset is not identified (the field has a length of zero), then the
             //  beginning of the source (offset 0) is implied"
             // This behavior will follow from BitReader::read_u64(0) -> 0.
-            let extent_offset = iloc.read_u64(offset_size.to_bits())?;
-            let extent_length = iloc.read_u64(length_size.to_bits())?.try_into()?;
+            let extent_offset = iloc.read_u64(offset_size.as_bits())?;
+            let extent_length = iloc.read_u64(length_size.as_bits())?.try_into()?;
 
             // "If the length is not specified, or specified as zero, then the entire length of
             //  the source is implied" (ibid)

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -294,7 +294,7 @@ pub struct Mp4parseIndice {
 #[repr(C)]
 #[derive(Debug)]
 pub struct Mp4parseByteData {
-    pub length: u32,
+    pub length: usize,
     // cheddar can't handle generic type, so it needs to be multiple data types here.
     pub data: *const u8,
     pub indices: *const Mp4parseIndice,
@@ -312,12 +312,12 @@ impl Default for Mp4parseByteData {
 
 impl Mp4parseByteData {
     fn set_data(&mut self, data: &[u8]) {
-        self.length = data.len() as u32;
+        self.length = data.len();
         self.data = data.as_ptr();
     }
 
     fn set_indices(&mut self, data: &[Mp4parseIndice]) {
-        self.length = data.len() as u32;
+        self.length = data.len();
         self.indices = data.as_ptr();
     }
 }
@@ -928,9 +928,9 @@ fn get_track_audio_info(
                 if esds.codec_esds.len() > std::u32::MAX as usize {
                     return Err(Mp4parseStatus::Invalid);
                 }
-                sample_info.extra_data.length = esds.codec_esds.len() as u32;
+                sample_info.extra_data.length = esds.codec_esds.len();
                 sample_info.extra_data.data = esds.codec_esds.as_ptr();
-                sample_info.codec_specific_config.length = esds.decoder_specific_data.len() as u32;
+                sample_info.codec_specific_config.length = esds.decoder_specific_data.len();
                 sample_info.codec_specific_config.data = esds.decoder_specific_data.as_ptr();
                 if let Some(rate) = esds.audio_sample_rate {
                     sample_info.sample_rate = rate;
@@ -952,7 +952,7 @@ fn get_track_audio_info(
                 if streaminfo.block_type != 0 || streaminfo.data.len() != 34 {
                     return Err(Mp4parseStatus::Invalid);
                 }
-                sample_info.codec_specific_config.length = streaminfo.data.len() as u32;
+                sample_info.codec_specific_config.length = streaminfo.data.len();
                 sample_info.codec_specific_config.data = streaminfo.data.as_ptr();
             }
             AudioCodecSpecific::OpusSpecificBox(ref opus) => {
@@ -967,14 +967,14 @@ fn get_track_audio_info(
                             if v.len() > std::u32::MAX as usize {
                                 return Err(Mp4parseStatus::Invalid);
                             }
-                            sample_info.codec_specific_config.length = v.len() as u32;
+                            sample_info.codec_specific_config.length = v.len();
                             sample_info.codec_specific_config.data = v.as_ptr();
                         }
                     }
                 }
             }
             AudioCodecSpecific::ALACSpecificBox(ref alac) => {
-                sample_info.codec_specific_config.length = alac.data.len() as u32;
+                sample_info.codec_specific_config.length = alac.data.len();
                 sample_info.codec_specific_config.data = alac.data.as_ptr();
             }
             AudioCodecSpecific::MP3 | AudioCodecSpecific::LPCM => (),


### PR DESCRIPTION
Also, fix a clippy lint