### PR TITLE
Fix clippy::cmp-owned on impl_bounded_product

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2026,7 +2026,7 @@ macro_rules! impl_bounded_product {
 
         impl $name {
             pub fn new(value: $inner) -> Self {
-                assert!(<$inner>::from(value) <= Self::MAX);
+                assert!(value <= Self::MAX);
                 Self(value)
             }
 


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#cmp_owned
Surfaced by https://github.com/mozilla/mp4parse-rust/runs/2443009191