### PR TITLE
Fix clippy needless-borrow lint

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -902,7 +902,7 @@ impl AvifContext {
         match &item.image_data {
             IsobmffItem::Location(extent) => {
                 for mdat in &self.item_storage {
-                    if let Some(slice) = mdat.get(&extent) {
+                    if let Some(slice) = mdat.get(extent) {
                         return slice;
                     }
                 }


### PR DESCRIPTION
```
error: this expression borrows a reference (`&Extent`) that is immediately dereferenced by the compiler
   --> mp4parse/src/lib.rs:907:51
    |
907 |                     if let Some(slice) = mdat.get(&extent) {
    |                                                   ^^^^^^^ help: change this to: `extent`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```