### PR TITLE
Use the same version of fallible_collections

### DIFF
--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -25,7 +25,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.2.1"
-fallible_collections = { version = "0.3", features = ["std_io"] }
+fallible_collections = { version = "0.4", features = ["std_io"] }
 log = "0.4"
 mp4parse = { version = "0.11.5", path = "../mp4parse", features = ["unstable-api"] }
 num-traits = "0.2.14"


### PR DESCRIPTION
There's no good reason `mp4parse` and `mp4parse_capi` should be using different versions