### PR TITLE
Fail actions run for nightly failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,15 @@ jobs:
           - os: ubuntu-20.04
             rust: nightly
             release: false
-            experimental: true
+            experimental: false
           - os: windows-2019
             rust: nightly
             release: false
-            experimental: true
+            experimental: false
           - os: macos-10.15
             rust: nightly
             release: false
-            experimental: true
+            experimental: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Without failing the whole run, it's hard to notice when we get failures in nightly, but nightly should be the advance notice that we pay attention to.