### PR TITLE
Remove #[deny(unreachable_patterns)]

### DIFF
--- a/mp4parse/src/boxes.rs
+++ b/mp4parse/src/boxes.rs
@@ -98,7 +98,6 @@ impl PartialEq<&[u8; 4]> for FourCC {
     }
 }
 
-#[deny(unreachable_patterns)]
 box_database!(
     FileTypeBox                       0x6674_7970, // "ftyp"
     MediaDataBox                      0x6d64_6174, // "mdat"


### PR DESCRIPTION
The current code causes a lint error in CI (https://github.com/mozilla/mp4parse-rust/actions/runs/1074468202):
```
error: unused attribute `deny`
   --> mp4parse/src/boxes.rs:101:1
    |
101 | #[deny(unreachable_patterns)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-attributes` implied by `-D warnings`
note: the built-in attribute `deny` will be ignored, since it's applied to the macro invocation `box_database`
   --> mp4parse/src/boxes.rs:102:1
    |
102 | box_database!(
    | ^^^^^^^^^^^^
```

Since this lint is already globally enabled as a warning, and our CI uses the ` -D warnings` option, this check will already be enabled as a CI fatal error