### PR TITLE
Drop unused and duplicated dependency on hashbrown

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -30,7 +30,6 @@ byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
 env_logger = "0.8"
 fallible_collections = { version = "0.4", features = ["std_io"] }
-hashbrown = "0.11"
 num-traits = "0.2.14"
 log = "0.4"
 static_assertions = "1.1.0"


### PR DESCRIPTION
Requiring hashbrown = v0.11 ends up causing hashbrown to be built twice. Once for mp4parse and and v0.9 for faillable-collections. hashbrown doesn't appear directly used by mp4parse, so we can just drop the requirement on v0.11.