### PR TITLE
Add "missing-pixi-permitted" feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build Rust ${{ matrix.rust }} on ${{ matrix.os }}, release=${{ matrix.release }}
+    name: Build Rust ${{ matrix.rust }} on ${{ matrix.os }}, release=${{ matrix.release }} features=${{ matrix.features }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -18,6 +18,7 @@ jobs:
         rust: [stable]
         release: [true, false]
         experimental: [false]
+        features: ["", "missing-pixi-permitted"]
         include:
           - os: ubuntu-20.04
             rust: nightly
@@ -54,12 +55,12 @@ jobs:
 
     - name: Test (release)
       shell: bash
-      run: rustup run ${{ matrix.rust }} cargo test --all --verbose --release
+      run: rustup run ${{ matrix.rust }} cargo test --all --features "${{ matrix.features }}" --verbose --release
       if: matrix.release
 
     - name: Test (debug)
       shell: bash
-      run: rustup run ${{ matrix.rust }} cargo test --all --verbose
+      run: rustup run ${{ matrix.rust }} cargo test --all --features "${{ matrix.features }}" --verbose
       if: ${{ !matrix.release }}
 
     # cargo-fuzz supports x86-64 Linux and x86-64 macOS, but macOS currently fails, see:

--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -40,6 +40,7 @@ walkdir = "2.3.1"
 criterion = "0.3"
 
 [features]
+missing-pixi-permitted = []
 3gpp = []
 meta-xml = []
 unstable-api = []

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1711,8 +1711,12 @@ pub fn read_avif<T: Read>(f: &mut T, strictness: ParseStrictness) -> Result<Avif
             .map_or(false, |opt| opt.is_some())
     };
     if !has_pixi(primary_item_id) || !alpha_item_id.map_or(true, has_pixi) {
+        // The requirement to include pixi is in the process of being changed
+        // to allowing its omission to imply a default value. In anticipation
+        // of that, only give an error in strict mode
+        // See https://github.com/MPEGGroup/MIAF/issues/9
         fail_if(
-            strictness != ParseStrictness::Permissive,
+            strictness == ParseStrictness::Strict,
             "The pixel information property shall be associated with every image \
              that is displayable (not hidden) \
              per MIAF (ISO/IEC 23000-22:2019) specification § 7.3.6.6",

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1716,7 +1716,11 @@ pub fn read_avif<T: Read>(f: &mut T, strictness: ParseStrictness) -> Result<Avif
         // of that, only give an error in strict mode
         // See https://github.com/MPEGGroup/MIAF/issues/9
         fail_if(
-            strictness == ParseStrictness::Strict,
+            if cfg!(feature = "missing-pixi-permitted") {
+                strictness == ParseStrictness::Strict
+            } else {
+                strictness != ParseStrictness::Permissive
+            },
             "The pixel information property shall be associated with every image \
              that is displayable (not hidden) \
              per MIAF (ISO/IEC 23000-22:2019) specification § 7.3.6.6",

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -923,8 +923,8 @@ fn public_avif_pixi_present_for_displayable_images() {
     let expected_msg = "The pixel information property shall be associated with every image \
                         that is displayable (not hidden) \
                         per MIAF (ISO/IEC 23000-22:2019) specification § 7.3.6.6";
-    assert_avif_shall(IMAGE_AVIF_NO_PIXI, expected_msg);
-    assert_avif_shall(IMAGE_AVIF_NO_ALPHA_PIXI, expected_msg);
+    assert_avif_should(IMAGE_AVIF_NO_PIXI, expected_msg);
+    assert_avif_should(IMAGE_AVIF_NO_ALPHA_PIXI, expected_msg);
 }
 
 #[test]

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -923,8 +923,14 @@ fn public_avif_pixi_present_for_displayable_images() {
     let expected_msg = "The pixel information property shall be associated with every image \
                         that is displayable (not hidden) \
                         per MIAF (ISO/IEC 23000-22:2019) specification § 7.3.6.6";
-    assert_avif_should(IMAGE_AVIF_NO_PIXI, expected_msg);
-    assert_avif_should(IMAGE_AVIF_NO_ALPHA_PIXI, expected_msg);
+    let pixi_test = if cfg!(feature = "missing-pixi-permitted") {
+        assert_avif_should
+    } else {
+        assert_avif_shall
+    };
+
+    pixi_test(IMAGE_AVIF_NO_PIXI, expected_msg);
+    pixi_test(IMAGE_AVIF_NO_ALPHA_PIXI, expected_msg);
 }
 
 #[test]

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -34,6 +34,7 @@ num-traits = "0.2.14"
 env_logger = "0.8"
 
 [features]
+missing-pixi-permitted = ["mp4parse/missing-pixi-permitted"]
 3gpp = ["mp4parse/3gpp"]
 meta-xml = ["mp4parse/meta-xml"]
 mp4v = ["mp4parse/mp4v"]


### PR DESCRIPTION
Currently the `PixelInformationProperty` (`pixi`) box defined in HEIF (ISO 23008-12:2017) § 6.5.6 is required to be present per MIAF (ISO/IEC 23000-22:2019) specification § 7.3.6.6:
> The pixel information property shall be associated with every image that is displayable (not hidden) 

However due to a bug ([now fixed](https://github.com/strukturag/libheif/commit/f8e2306c8f803fc158e6decb32ff1c78d1f7eef8)) in [libheif](https://github.com/strukturag/libheif), AVIF images lacking this property were created and may remain in the wild. After receiving https://bugs.chromium.org/p/chromium/issues/detail?id=1198455, Chrome relaxed their check for this requirement and it is unclear whether it will be reinstated.

Discussion is underway to modify MIAF to allow the pixi property to be omitted, but it's unclear whether or when that will happen. To allow for maximum flexibility to adjust mp4parse's behavior, this PR adds a `"missing-pixi-permitted"` feature so the behavior can be finely tuned from within gecko without requiring an update of mp4parse code.

https://github.com/mozilla/mp4parse-rust/commit/47bff4cab7fa656acb2fe25a2bfbb16226a9e2cd makes the change assuming https://github.com/MPEGGroup/MIAF/issues/9 will be accepted. https://github.com/mozilla/mp4parse-rust/commit/891df7c59549c31aedeb908be89c82bea028f326 adds the feature and test changes that are only required during this period of uncertainty and can be removed later.
 
See also
- https://github.com/MPEGGroup/MIAF/issues/9
- https://github.com/mozilla/mp4parse-rust/issues/287
- https://github.com/AOMediaCodec/libavif/issues/564