### PR TITLE
Add `cargo doc` to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,13 @@ jobs:
       run: rustup run ${{ matrix.rust }} cargo test --all --verbose
       if: ${{ !matrix.release }}
 
+    - name: Doc (release)
+      shell: bash
+      run: rustup run ${{ matrix.rust }} cargo doc --document-private-items
+      env:
+        RUSTDOCFLAGS: "-Dwarnings"
+      if: matrix.release
+
     # cargo-fuzz supports x86-64 Linux and x86-64 macOS, but macOS currently fails, see:
     # https://github.com/mozilla/mp4parse-rust/pull/210#issuecomment-597420191
     - name: Install cargo-fuzz

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -483,7 +483,7 @@ pub struct VPxConfigBox {
     pub codec_init: TryVec<u8>,
 }
 
-/// See AV1-ISOBMFF § 2.3.3 https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+/// See [AV1-ISOBMFF § 2.3.3](https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax)
 #[derive(Debug)]
 pub struct AV1ConfigBox {
     pub profile: u8,
@@ -502,7 +502,6 @@ pub struct AV1ConfigBox {
 }
 
 impl AV1ConfigBox {
-    /// See https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
     const CONFIG_OBUS_OFFSET: usize = 4;
 
     pub fn config_obus(&self) -> &[u8] {
@@ -3733,7 +3732,7 @@ fn read_vpcc<T: Read>(src: &mut BMFFBox<T>) -> Result<VPxConfigBox> {
     })
 }
 
-/// See AV1-ISOBMFF § 2.3.3 https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax
+/// See [AV1-ISOBMFF § 2.3.3](https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-syntax)
 fn read_av1c<T: Read>(src: &mut BMFFBox<T>) -> Result<AV1ConfigBox> {
     // We want to store the raw config as well as a structured (parsed) config, so create a copy of
     // the raw config so we have it later, and then parse the structured data from that.
@@ -4124,7 +4123,7 @@ fn read_esds<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
 }
 
 /// Parse `FLACSpecificBox`.
-/// See https://github.com/xiph/flac/blob/master/doc/isoflac.txt §  3.3.2
+/// See [Encapsulation of FLAC in ISO Base Media File Format](https://github.com/xiph/flac/blob/master/doc/isoflac.txt) §  3.3.2
 fn read_dfla<T: Read>(src: &mut BMFFBox<T>) -> Result<FLACSpecificBox> {
     let (version, flags) = read_fullbox_extra(src)?;
     if version != 0 {


### PR DESCRIPTION
This was present in the travis configuration that was removed in https://github.com/mozilla/mp4parse-rust/commit/f3c5f88d93da28c6c6dcd6d352d5ba9baab3b354. It remains useful since it can catch errors in the rustdoc such as in https://travis-ci.org/github/mozilla/mp4parse-rust/jobs/774702058