### PR TITLE
Run clippy on fuzzer code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,3 +81,7 @@ jobs:
       run: rustup run ${{ matrix.rust }} cargo fuzz build
       if: ${{ matrix.os == 'ubuntu-20.04' && matrix.rust == 'nightly' }}
 
+    - name: Clippy fuzzer
+      working-directory: mp4parse_capi/fuzz
+      run: rustup run ${{ matrix.rust }} cargo clippy -- -D warnings
+      if: ${{ matrix.os == 'ubuntu-20.04' && matrix.rust == 'nightly' }}


### PR DESCRIPTION
I checked this worked by intentionally re-introducing a warning for this run: https://github.com/mozilla/mp4parse-rust/runs/3366215594

It's now been reverted and everything should be green.