### PR TITLE
Expose the pixel information (pixi) via the C API

### DIFF
--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -758,7 +758,7 @@ fn public_avif_primary_item() {
     let input = &mut File::open(IMAGE_AVIF).expect("Unknown file");
     let context = mp4::read_avif(input, ParseStrictness::Normal).expect("read_avif failed");
     assert_eq!(
-        context.primary_item(),
+        context.primary_item_coded_data(),
         [
             0x12, 0x00, 0x0A, 0x07, 0x38, 0x00, 0x06, 0x90, 0x20, 0x20, 0x69, 0x32, 0x0C, 0x16,
             0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x79, 0x4C, 0xD2, 0x02
@@ -770,7 +770,7 @@ fn public_avif_primary_item() {
 fn public_avif_primary_item_split_extents() {
     let input = &mut File::open(IMAGE_AVIF_EXTENTS).expect("Unknown file");
     let context = mp4::read_avif(input, ParseStrictness::Normal).expect("read_avif failed");
-    assert_eq!(context.primary_item().len(), 52);
+    assert_eq!(context.primary_item_coded_data().len(), 52);
 }
 
 #[test]
@@ -783,7 +783,7 @@ fn public_avif_alpha_item() {
 fn public_avif_alpha_non_premultiplied() {
     let input = &mut File::open(IMAGE_AVIF_ALPHA).expect("Unknown file");
     let context = mp4::read_avif(input, ParseStrictness::Normal).expect("read_avif failed");
-    assert!(context.alpha_item().is_some());
+    assert!(!context.alpha_item_coded_data().is_empty());
     assert!(!context.premultiplied_alpha);
 }
 
@@ -791,7 +791,7 @@ fn public_avif_alpha_non_premultiplied() {
 fn public_avif_alpha_premultiplied() {
     let input = &mut File::open(IMAGE_AVIF_ALPHA_PREMULTIPLIED).expect("Unknown file");
     let context = mp4::read_avif(input, ParseStrictness::Normal).expect("read_avif failed");
-    assert!(context.alpha_item().is_some());
+    assert!(!context.alpha_item_coded_data().is_empty());
     assert!(context.premultiplied_alpha);
     assert_avif_valid(input);
 }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -316,16 +316,23 @@ pub struct Mp4parseParser {
 
 #[repr(C)]
 #[derive(Debug)]
+pub struct Mp4parseAvifImageItem {
+    pub coded_data: Mp4parseByteData,
+    pub bits_per_channel: Mp4parseByteData,
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct Mp4parseAvifImage {
-    pub primary_item: Mp4parseByteData,
+    pub primary_image: Mp4parseAvifImageItem,
     /// The size of the image; should never be null unless using permissive parsing
     pub spatial_extents: *const mp4parse::ImageSpatialExtentsProperty,
     pub nclx_colour_information: *const mp4parse::NclxColourInformation,
     pub icc_colour_information: Mp4parseByteData,
     pub image_rotation: mp4parse::ImageRotation,
     pub image_mirror: *const mp4parse::ImageMirror,
-    /// If no alpha item exists, `.length` will be 0 and `.data` will be null
-    pub alpha_item: Mp4parseByteData,
+    /// If no alpha item exists, members' `.length` will be 0 and `.data` will be null
+    pub alpha_image: Mp4parseAvifImageItem,
     pub premultiplied_alpha: bool,
 }
 
@@ -1022,8 +1029,8 @@ fn mp4parse_get_track_video_info_safe(
 /// pointer points to a valid `Mp4parseAvifParser`, and that the avif_image
 /// pointer points to a valid `Mp4parseAvifImage`. If there was not a previous
 /// successful call to `mp4parse_avif_read()`, no guarantees are made as to
-/// the state of `avif_image`. If `avif_image.alpha_item` is set to a
-/// positive `length` and non-null `data`, then the `avif_image` contains an
+/// the state of `avif_image`. If `avif_image.alpha_image.coded_data` is set to
+/// a positive `length` and non-null `data`, then the `avif_image` contains a
 /// valid alpha channel data. Otherwise, the image is opaque.
 #[no_mangle]
 pub unsafe extern "C" fn mp4parse_avif_get_image(
@@ -1047,17 +1054,25 @@ pub fn mp4parse_avif_get_image_safe(
 ) -> mp4parse::Result<Mp4parseAvifImage> {
     let context = parser.context();
 
+    let primary_image = Mp4parseAvifImageItem {
+        coded_data: Mp4parseByteData::with_data(context.primary_item_coded_data()),
+        bits_per_channel: Mp4parseByteData::with_data(context.primary_item_bits_per_channel()?),
+    };
+
+    // If there is no alpha present, all the `Mp4parseByteData`s will be zero length
+    let alpha_image = Mp4parseAvifImageItem {
+        coded_data: Mp4parseByteData::with_data(context.alpha_item_coded_data()),
+        bits_per_channel: Mp4parseByteData::with_data(context.alpha_item_bits_per_channel()?),
+    };
+
     Ok(Mp4parseAvifImage {
-        primary_item: Mp4parseByteData::with_data(context.primary_item()),
+        primary_image,
         spatial_extents: context.spatial_extents_ptr()?,
         nclx_colour_information: context.nclx_colour_information_ptr()?,
         icc_colour_information: Mp4parseByteData::with_data(context.icc_colour_information()?),
         image_rotation: context.image_rotation()?,
         image_mirror: context.image_mirror_ptr()?,
-        alpha_item: context
-            .alpha_item()
-            .map(Mp4parseByteData::with_data)
-            .unwrap_or_default(),
+        alpha_image,
         premultiplied_alpha: context.premultiplied_alpha,
     })
 }


### PR DESCRIPTION
This is required for https://bugzilla.mozilla.org/show_bug.cgi?id=1696045, so that we can record telemetry on whether the `pixi` box is present