### PR TITLE
Remove obsolete clippy::wrong_self_convention

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -71,8 +71,6 @@ impl ToU64 for usize {
 /// A trait to indicate a type can be infallibly converted to `usize`.
 /// This should only be implemented for infallible conversions, so only unsigned types are valid.
 pub trait ToUsize {
-    // Remove when https://github.com/rust-lang/rust-clippy/issues/6727 is resolved
-    #[allow(clippy::wrong_self_convention)]
     fn to_usize(self) -> usize;
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/6727 has been fixed, so this is no longer necessary