### PR TITLE
Fix `clippy::needless-borrow`

### DIFF
--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -14,8 +14,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/fuzz/fuzz_targets/avif.rs
+++ b/mp4parse_capi/fuzz/fuzz_targets/avif.rs
@@ -10,8 +10,8 @@ type CursorType<'a> = std::io::Cursor<&'a [u8]>;
 extern "C" fn vec_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut CursorType = unsafe { &mut *(userdata as *mut _) };
 
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n.try_into().expect("invalid conversion"),
         Err(_) => -1,
     }

--- a/mp4parse_capi/fuzz/fuzz_targets/mp4.rs
+++ b/mp4parse_capi/fuzz/fuzz_targets/mp4.rs
@@ -10,8 +10,8 @@ type CursorType<'a> = std::io::Cursor<&'a [u8]>;
 extern "C" fn vec_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut CursorType = unsafe { &mut *(userdata as *mut _) };
 
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n.try_into().expect("invalid conversion"),
         Err(_) => -1,
     }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1312,8 +1312,8 @@ extern "C" fn error_read(_: *mut u8, _: usize, _: *mut std::os::raw::c_void) -> 
 extern "C" fn valid_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
 
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_chunk_out_of_range.rs
+++ b/mp4parse_capi/tests/test_chunk_out_of_range.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_encryption.rs
+++ b/mp4parse_capi/tests/test_encryption.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_rotation.rs
+++ b/mp4parse_capi/tests/test_rotation.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -6,8 +6,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }

--- a/mp4parse_capi/tests/test_workaround_stsc.rs
+++ b/mp4parse_capi/tests/test_workaround_stsc.rs
@@ -4,8 +4,8 @@ use std::io::Read;
 
 extern "C" fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
     let input: &mut std::fs::File = unsafe { &mut *(userdata as *mut _) };
-    let mut buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
-    match input.read(&mut buf) {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, size) };
+    match input.read(buf) {
         Ok(n) => n as isize,
         Err(_) => -1,
     }


### PR DESCRIPTION
and consequently some `unused-mut` warnings

Identified by scheduled CI in https://github.com/mozilla/mp4parse-rust/runs/3754585345