### PR TITLE
Update version in anticipation of release on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ Test coverage comes from several sources:
 - Examples are included under `mp4parse_capi/examples`. These programs should
 continue to build and run after changes are made. Note, these programs are not
 typically run by `cargo test`, so manual verification is required.
+
+# Versioning
+
+Prior to Firefox 95, versions of this library have been updated sporadically,
+and uploaded to crates.io even less frequently. Going forward, there will be
+a new release on github and crates.io whenever the version of the code used
+in Firefox (see [toolkit/library/rust/shared/Cargo.toml](https://searchfox.org/mozilla-central/source/toolkit/library/rust/shared/Cargo.toml#12)) is updated. For convenience, the
+patch version will correspond to the first Firefox version the code is used in.
+For example, v0.12.95 will be the version of the code used in Firefox 95.

--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.11.6"
+version = "0.12.95"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.11.6"
+version = "0.12.95"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -27,7 +27,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 byteorder = "1.2.1"
 fallible_collections = { version = "0.4", features = ["std_io"] }
 log = "0.4"
-mp4parse = { version = "0.11.6", path = "../mp4parse", features = ["unstable-api"] }
+mp4parse = { version = "0.12.95", path = "../mp4parse", features = ["unstable-api"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]


### PR DESCRIPTION
This can be merged here now, but the release on github and crates shouldn't be published until Firefox 95 ships (December 7) so that the patch version matches the earliest version of the Firefox release it's used in. See README.md for more.

See https://github.com/mozilla/mp4parse-rust/issues/339