### PR TITLE
Bump version to 0.11.6 for new release

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.11.5"
+version = "0.11.6"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.11.5"
+version = "0.11.6"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -27,7 +27,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 byteorder = "1.2.1"
 fallible_collections = { version = "0.4", features = ["std_io"] }
 log = "0.4"
-mp4parse = { version = "0.11.5", path = "../mp4parse", features = ["unstable-api"] }
+mp4parse = { version = "0.11.6", path = "../mp4parse", features = ["unstable-api"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]


### PR DESCRIPTION
While our new release strategy will start with v0.12.95 around December 7th with the changes in https://github.com/mozilla/mp4parse-rust/pull/347, I didn't want to make https://github.com/mozilla/mp4parse-rust/issues/339 wait so long to be resolved. This will allow for an updated release which is not in sync with any particular Firefox version.