### PR TITLE
Update version 0.11.6 -> 0.12.0 due to breaking API changes

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse"
-version = "0.11.6"
+version = "0.12.0"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp4parse_capi"
-version = "0.11.6"
+version = "0.12.0"
 authors = [
   "Ralph Giles <giles@mozilla.com>",
   "Matthew Gregan <kinetik@flim.org>",
@@ -27,7 +27,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 byteorder = "1.2.1"
 fallible_collections = { version = "0.4", features = ["std_io"] }
 log = "0.4"
-mp4parse = { version = "0.11.6", path = "../mp4parse", features = ["unstable-api"] }
+mp4parse = { version = "0.12.0", path = "../mp4parse", features = ["unstable-api"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]


### PR DESCRIPTION
0.11.6 has been yanked from crates.io and https://github.com/mozilla/mp4parse-rust/releases
This will re-release the same code, with a semver appropriate version

See https://github.com/mozilla/mp4parse-rust/issues/349