### PR TITLE
Fix `clippy::question-mark` lint

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -227,6 +227,12 @@ impl From<fallible_collections::TryReserveError> for Status {
     }
 }
 
+impl From<std::io::Error> for Status {
+    fn from(_: std::io::Error) -> Self {
+        Status::Io
+    }
+}
+
 /// Describes parser failures.
 ///
 /// This enum wraps the standard `io::Error` type, unified with

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1287,12 +1287,7 @@ fn get_pssh_info(
             .try_into()
             .map_err(|_| Mp4parseStatus::Invalid)?;
         let mut data_len = TryVec::new();
-        if data_len
-            .write_u32::<byteorder::NativeEndian>(content_len)
-            .is_err()
-        {
-            return Err(Mp4parseStatus::Io);
-        }
+        data_len.write_u32::<byteorder::NativeEndian>(content_len)?;
         pssh_data.extend_from_slice(pssh.system_id.as_slice())?;
         pssh_data.extend_from_slice(data_len.as_slice())?;
         pssh_data.extend_from_slice(pssh.box_content.as_slice())?;


### PR DESCRIPTION
Note it was necessary to add a `From<std::io::Error> for Status` impl for this

Original clippy error:
```
warning: this block may be rewritten with the `?` operator
    --> mp4parse_capi/src/lib.rs:1290:9
     |
1290 | /         if data_len
1291 | |             .write_u32::<byteorder::NativeEndian>(content_len)
1292 | |             .is_err()
1293 | |         {
1294 | |             return Err(Mp4parseStatus::Io);
1295 | |         }
     | |_________^
     |
     = note: `-D clippy::question-mark` implied by `-D warnings`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
help: replace it with
     |
1290 ~         data_len
1291 +             .write_u32::<byteorder::NativeEndian>(content_len)?;
     |
```