### PR TITLE
Remove obsolete clippy::wrong_self_convention, again

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -51,8 +51,6 @@ const MIF1_BRAND: FourCC = FourCC { value: *b"mif1" };
 /// A trait to indicate a type can be infallibly converted to `u64`.
 /// This should only be implemented for infallible conversions, so only unsigned types are valid.
 trait ToU64 {
-    // Remove when https://github.com/rust-lang/rust-clippy/issues/6727 is resolved
-    #[allow(clippy::wrong_self_convention)]
     fn to_u64(self) -> u64;
 }
 


### PR DESCRIPTION
Missed a spot with https://github.com/mozilla/mp4parse-rust/pull/337