### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -13,7 +13,7 @@ description = "Parser for ISO base media file format (mp4)"
 documentation = "https://docs.rs/mp4parse/"
 license = "MPL-2.0"
 categories = ["multimedia::video"]
-
+edition = "2018"
 repository = "https://github.com/mozilla/mp4parse-rust"
 
 # Avoid complaints about trying to package test files.

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -35,7 +35,7 @@ use std::io::{Read, Take};
 mod macros;
 
 mod boxes;
-use boxes::{BoxType, FourCC};
+use crate::boxes::{BoxType, FourCC};
 
 // Unit tests.
 #[cfg(test)]
@@ -3188,7 +3188,7 @@ macro_rules! impl_bounded_product {
 }
 
 mod bounded_uints {
-    use UpperBounded;
+    use crate::UpperBounded;
 
     impl_bounded!(U8, u8);
     impl_bounded!(U16, u16);
@@ -3203,7 +3203,7 @@ mod bounded_uints {
     }
 }
 
-use bounded_uints::*;
+use crate::bounded_uints::*;
 
 /// Implement the multiplication operator for $lhs * $rhs giving $output, which
 /// is internally represented as $inner. The operation is statically checked

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -16,7 +16,7 @@ use std::io::Read as _;
 extern crate test_assembler;
 use self::test_assembler::*;
 
-use boxes::BoxType;
+use crate::boxes::BoxType;
 
 enum BoxSize {
     Short(u32),

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -4,7 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 extern crate mp4parse as mp4;
 
-use mp4::{Error, ParseStrictness, Status};
+use crate::mp4::{Error, ParseStrictness, Status};
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::{Cursor, Read, Seek, SeekFrom};

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Parser for ISO base media file format (mp4)"
 documentation = "https://docs.rs/mp4parse_capi/"
 license = "MPL-2.0"
-
+edition = "2018"
 repository = "https://github.com/mozilla/mp4parse-rust"
 
 # Avoid complaints about trying to package test files.


### PR DESCRIPTION
This create already won't work with 2015-only versions of Rust, so it may as well update to a newer edition.