### PR TITLE
Remove `extern crate` statements

### DIFF
--- a/mp4parse/benches/avif_benchmark.rs
+++ b/mp4parse/benches/avif_benchmark.rs
@@ -1,8 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-extern crate criterion;
-extern crate mp4parse as mp4;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs::File;
@@ -19,5 +17,5 @@ fn avif_largest() {
         "av1-avif/testFiles/Netflix/avif/cosmos_frame05000_yuv444_12bpc_bt2020_pq_qlossless.avif",
     )
     .expect("Unknown file");
-    assert!(mp4::read_avif(input, mp4::ParseStrictness::Normal).is_ok());
+    assert!(mp4parse::read_avif(input, mp4parse::ParseStrictness::Normal).is_ok());
 }

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -307,14 +307,12 @@ impl UnsupportedFeatures {
 impl<T> From<Status> for Result<T> {
     /// A convenience method to enable shortcuts like
     /// ```
-    /// # extern crate mp4parse;
     /// # use mp4parse::{Result,Status};
     /// # let _: Result<()> =
     /// Status::MissingAvifOrAvisBrand.into();
     /// ```
     /// instead of
     /// ```
-    /// # extern crate mp4parse;
     /// # use mp4parse::{Error,Result,Status};
     /// # let _: Result<()> =
     /// Err(Error::from(Status::MissingAvifOrAvisBrand));

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -13,8 +13,7 @@ use fallible_collections::TryRead as _;
 use std::convert::TryInto as _;
 use std::io::Cursor;
 use std::io::Read as _;
-extern crate test_assembler;
-use self::test_assembler::*;
+use test_assembler::*;
 
 use crate::boxes::BoxType;
 

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -2,7 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-extern crate mp4parse as mp4;
+use mp4parse as mp4;
 
 use crate::mp4::{Error, ParseStrictness, Status};
 use std::convert::TryInto;

--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -1,11 +1,4 @@
-extern crate mp4parse;
-extern crate mp4parse_capi;
-
-#[macro_use]
-extern crate log;
-
-extern crate env_logger;
-
+use log::info;
 use mp4parse::ParseStrictness;
 use mp4parse_capi::*;
 use std::env;

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -5,7 +5,6 @@
 //! # Examples
 //!
 //! ```rust
-//! extern crate mp4parse_capi;
 //! use std::io::Read;
 //!
 //! extern fn buf_read(buf: *mut u8, size: usize, userdata: *mut std::os::raw::c_void) -> isize {
@@ -34,11 +33,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-extern crate byteorder;
-extern crate log;
-extern crate mp4parse;
-extern crate num_traits;
 
 use byteorder::WriteBytesExt;
 use std::convert::TryFrom;

--- a/mp4parse_capi/tests/test_chunk_out_of_range.rs
+++ b/mp4parse_capi/tests/test_chunk_out_of_range.rs
@@ -1,4 +1,3 @@
-extern crate mp4parse_capi;
 use mp4parse_capi::*;
 use std::io::Read;
 

--- a/mp4parse_capi/tests/test_encryption.rs
+++ b/mp4parse_capi/tests/test_encryption.rs
@@ -1,4 +1,3 @@
-extern crate mp4parse_capi;
 use mp4parse_capi::*;
 use std::io::Read;
 

--- a/mp4parse_capi/tests/test_fragment.rs
+++ b/mp4parse_capi/tests/test_fragment.rs
@@ -1,4 +1,3 @@
-extern crate mp4parse_capi;
 use mp4parse_capi::*;
 use std::io::Read;
 

--- a/mp4parse_capi/tests/test_rotation.rs
+++ b/mp4parse_capi/tests/test_rotation.rs
@@ -1,4 +1,3 @@
-extern crate mp4parse_capi;
 use mp4parse_capi::*;
 use std::io::Read;
 

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -1,5 +1,3 @@
-extern crate mp4parse;
-extern crate mp4parse_capi;
 use mp4parse::unstable::Indice;
 use mp4parse_capi::*;
 use std::io::Read;

--- a/mp4parse_capi/tests/test_workaround_stsc.rs
+++ b/mp4parse_capi/tests/test_workaround_stsc.rs
@@ -1,4 +1,3 @@
-extern crate mp4parse_capi;
 use mp4parse_capi::*;
 use std::io::Read;
 


### PR DESCRIPTION
These are no longer necessary in the 2018 edition
See https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html