### PR TITLE
Permit multiple nuls in `hdlr` box `name` field.

### DIFF
--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -491,7 +491,7 @@ fn read_hdlr_multiple_nul_in_name() {
     assert_eq!(stream.head.size, 45);
     assert_eq!(
         super::Status::from(super::read_hdlr(&mut stream, ParseStrictness::Strict)),
-        super::Status::HdlrNameMultipleNul,
+        super::Status::Ok,
     );
 }
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -643,7 +643,7 @@ fn make_dfla(
 ) -> Cursor<Vec<u8>> {
     assert!(data.len() < 1 << 24);
     make_fullbox(BoxSize::Auto, b"dfLa", 0, |s| {
-        let flag = if last { 1 } else { 0 };
+        let flag = u32::from(last);
         let size = match data_length {
             FlacBlockLength::Correct => (data.len() as u32) & 0x00ff_ffff,
             FlacBlockLength::Incorrect(size) => {

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -1325,6 +1325,6 @@ fn read_to_end_() {
 
 #[test]
 fn read_to_end_oom() {
-    let mut src = b"1234567890".take(std::usize::MAX.try_into().expect("usize < u64"));
+    let mut src = b"1234567890".take(std::isize::MAX.try_into().expect("isize < u64"));
     assert!(src.read_into_try_vec().is_err());
 }

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -1060,7 +1060,7 @@ fn public_avif_hdlr_multiple_nul() {
     // This is a "should" despite the spec indicating a (somewhat ambiguous)
     // requirement about extra data in boxes
     // See comments in read_hdlr
-    assert_avif_should(IMAGE_AVIF_HDLR_MULTIPLE_NUL, Status::HdlrNameMultipleNul);
+    assert_avif_should(IMAGE_AVIF_HDLR_MULTIPLE_NUL, Status::Ok);
 }
 
 #[test]


### PR DESCRIPTION
`name` should be truncated after the first nul but we don't store the `name` field so this change just lifts the restriction on multiple nul bytes.

This reflects the spec clarification accepted in https://github.com/MPEGGroup/FileFormat/issues/35