### PR TITLE
Remove env_logger dependency.

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -28,7 +28,6 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-env_logger = "0.9"
 fallible_collections = { version = "0.4", features = ["std_io"] }
 num-traits = "0.2.14"
 log = "0.4"

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2476,8 +2476,6 @@ impl AvifImageType {
 
 /// Read the contents of an AVIF file
 pub fn read_avif<T: Read>(f: &mut T, strictness: ParseStrictness) -> Result<AvifContext> {
-    let _ = env_logger::try_init();
-
     debug!("read_avif(strictness: {:?})", strictness);
 
     let mut f = OffsetReader::new(f);


### PR DESCRIPTION
Libraries are not meant to initialize env_logger themselves.