### PR TITLE
Read the looping flag when `elst` box is empty.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -4402,6 +4402,7 @@ fn read_edts<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
         match b.head.name {
             BoxType::EditListBox => {
                 let elst = read_elst(&mut b)?;
+                track.looped = Some(elst.looped);
                 if elst.edits.is_empty() {
                     debug!("empty edit list");
                     continue;
@@ -4421,7 +4422,6 @@ fn read_edts<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
                 if media_time < 0 {
                     debug!("unexpected negative media time in edit");
                 }
-                track.looped = Some(elst.looped);
                 track.edited_duration = Some(MediaScaledTime(elst.edits[idx].segment_duration));
                 track.media_time = Some(TrackScaledTime::<u64>(
                     std::cmp::max(0, media_time) as u64,

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -1245,7 +1245,19 @@ fn public_avif_avis_major_no_moov() {
 #[test]
 fn public_avif_avis_with_no_pitm_no_iloc() {
     let input = &mut File::open(AVIF_AVIS_WITH_NO_PITM_NO_ILOC).expect("Unknown file");
-    assert!(mp4::read_avif(input, ParseStrictness::Normal).is_ok());
+    match mp4::read_avif(input, ParseStrictness::Normal) {
+        Ok(context) => {
+            assert_eq!(context.major_brand, mp4::AVIS_BRAND);
+            match context.sequence {
+                Some(sequence) => {
+                    assert!(!sequence.tracks.is_empty());
+                    assert_eq!(sequence.tracks[0].looped, Some(false));
+                }
+                None => panic!("Expected sequence"),
+            }
+        }
+        Err(e) => panic!("Expected Ok(_), found {:?}", e),
+    }
 }
 
 #[test]

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -7,7 +7,7 @@ use mp4parse as mp4;
 use crate::mp4::{ParseStrictness, Status};
 use std::convert::TryInto;
 use std::fs::File;
-use std::io::{Cursor, Read, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek};
 
 static MINI_MP4: &str = "tests/minimal.mp4";
 static MINI_MP4_WITH_METADATA: &str = "tests/metadata.mp4";
@@ -949,7 +949,7 @@ fn for_strictness_result(
         ParseStrictness::Normal,
         ParseStrictness::Strict,
     ] {
-        input.seek(SeekFrom::Start(0)).expect("rewind failed");
+        input.rewind().expect("rewind failed");
         check(strictness, mp4::read_avif(input, strictness));
     }
 }
@@ -1116,6 +1116,7 @@ fn public_avif_transform_order() {
     assert_avif_shall(IMAGE_AVIF_TRANSFORM_ORDER, Status::TxformOrder);
 }
 
+#[allow(clippy::uninlined_format_args)]
 fn assert_unsupported_nonfatal(result: &mp4::Result<mp4::AvifContext>, feature: mp4::Feature) {
     match result {
         Ok(context) => {


### PR DESCRIPTION
The test file with no `pitm` and no `iloc` boxes should have had a loop count of 0 due to their `elst` box flags being set to 0, but the looping field that was read was being skipped due to the empty edit list.

Note: these test files had to be modified manually using MP4Box in gpac, libavif will not write files with no edits.