### PR TITLE
Treat some with_capacity calls as a hint.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -161,6 +161,31 @@ struct HashMap;
 #[allow(dead_code)]
 struct String;
 
+// Arbitrary 1MB limit.
+const CAPACITY_HINT_LIMIT: usize = 1024 * 1024;
+
+/// Returns a `TryVec<T>` with preallocated capacity for up to `expected_items`.
+/// `expected_items` is treated as a hint only and the returned `TryVec<T>`'s
+/// capacity may be less than `expected_items`.
+fn vec_with_capacity_hint<T>(expected_items: usize) -> Result<TryVec<T>, TryReserveError> {
+    let reserved_items = expected_items.min(CAPACITY_HINT_LIMIT / std::mem::size_of::<T>());
+    TryVec::with_capacity(reserved_items)
+}
+
+/// Returns a `TryHashMap<T>` with preallocated capacity for up to `expected_items`.
+/// `expected_items` is treated as a hint only and the returned `TryHashMap<T>`'s
+/// capacity may be less than `expected_items`.
+fn hashmap_with_capacity_hint<K, V>(
+    expected_items: usize,
+) -> Result<TryHashMap<K, V>, TryReserveError>
+where
+    K: Eq + std::hash::Hash,
+{
+    let reserved_items = expected_items
+        .min(CAPACITY_HINT_LIMIT / (std::mem::size_of::<K>() + std::mem::size_of::<V>()));
+    TryHashMap::with_capacity(reserved_items)
+}
+
 /// The return value to the C API
 /// Any detail that needs to be communicated to the caller must be encoded here
 /// since the [`Error`] type's associated data is part of the FFI.
@@ -2962,7 +2987,7 @@ fn read_iinf<T: Read>(
     } else {
         be_u32(src)?.to_usize()
     };
-    let mut item_infos = TryVec::with_capacity(entry_count)?;
+    let mut item_infos = vec_with_capacity_hint(entry_count)?;
 
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
@@ -4071,7 +4096,7 @@ fn read_iloc<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<ItemId, ItemLoc
         IlocVersion::Two => iloc.read_u32(32)?,
     };
 
-    let mut items = TryHashMap::with_capacity(item_count.to_usize())?;
+    let mut items = hashmap_with_capacity_hint(item_count.to_usize())?;
 
     for _ in 0..item_count {
         let item_id = ItemId(match version {
@@ -4691,7 +4716,7 @@ fn read_tkhd<T: Read>(src: &mut BMFFBox<T>) -> Result<TrackHeaderBox> {
 fn read_elst<T: Read>(src: &mut BMFFBox<T>) -> Result<EditListBox> {
     let (version, flags) = read_fullbox_extra(src)?;
     let edit_count = be_u32(src)?;
-    let mut edits = TryVec::with_capacity(edit_count.to_usize())?;
+    let mut edits = vec_with_capacity_hint(edit_count.to_usize())?;
     for _ in 0..edit_count {
         let (segment_duration, media_time) = match version {
             1 => {
@@ -4770,7 +4795,7 @@ fn read_mdhd<T: Read>(src: &mut BMFFBox<T>) -> Result<MediaHeaderBox> {
 fn read_stco<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
     let (_, _) = read_fullbox_extra(src)?;
     let offset_count = be_u32(src)?;
-    let mut offsets = TryVec::with_capacity(offset_count.to_usize())?;
+    let mut offsets = vec_with_capacity_hint(offset_count.to_usize())?;
     for _ in 0..offset_count {
         offsets.push(be_u32(src)?.into())?;
     }
@@ -4786,7 +4811,7 @@ fn read_stco<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
 fn read_co64<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
     let (_, _) = read_fullbox_extra(src)?;
     let offset_count = be_u32(src)?;
-    let mut offsets = TryVec::with_capacity(offset_count.to_usize())?;
+    let mut offsets = vec_with_capacity_hint(offset_count.to_usize())?;
     for _ in 0..offset_count {
         offsets.push(be_u64(src)?)?;
     }
@@ -4802,7 +4827,7 @@ fn read_co64<T: Read>(src: &mut BMFFBox<T>) -> Result<ChunkOffsetBox> {
 fn read_stss<T: Read>(src: &mut BMFFBox<T>) -> Result<SyncSampleBox> {
     let (_, _) = read_fullbox_extra(src)?;
     let sample_count = be_u32(src)?;
-    let mut samples = TryVec::with_capacity(sample_count.to_usize())?;
+    let mut samples = vec_with_capacity_hint(sample_count.to_usize())?;
     for _ in 0..sample_count {
         samples.push(be_u32(src)?)?;
     }
@@ -4818,7 +4843,7 @@ fn read_stss<T: Read>(src: &mut BMFFBox<T>) -> Result<SyncSampleBox> {
 fn read_stsc<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleToChunkBox> {
     let (_, _) = read_fullbox_extra(src)?;
     let sample_count = be_u32(src)?;
-    let mut samples = TryVec::with_capacity(sample_count.to_usize())?;
+    let mut samples = vec_with_capacity_hint(sample_count.to_usize())?;
     for _ in 0..sample_count {
         let first_chunk = be_u32(src)?;
         let samples_per_chunk = be_u32(src)?;
@@ -4850,7 +4875,7 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
         return Status::CttsBadSize.into();
     }
 
-    let mut offsets = TryVec::with_capacity(counts.to_usize())?;
+    let mut offsets = vec_with_capacity_hint(counts.to_usize())?;
     for _ in 0..counts {
         let (sample_count, time_offset) = match version {
             // According to spec, Version0 shoule be used when version == 0;
@@ -4904,7 +4929,7 @@ fn read_stsz<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleSizeBox> {
 fn read_stts<T: Read>(src: &mut BMFFBox<T>) -> Result<TimeToSampleBox> {
     let (_, _) = read_fullbox_extra(src)?;
     let sample_count = be_u32(src)?;
-    let mut samples = TryVec::with_capacity(sample_count.to_usize())?;
+    let mut samples = vec_with_capacity_hint(sample_count.to_usize())?;
     for _ in 0..sample_count {
         let sample_count = be_u32(src)?;
         let sample_delta = be_u32(src)?;
@@ -5892,7 +5917,7 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &mut Track) -> Result<SampleD
     }
 
     let description_count = be_u32(src)?.to_usize();
-    let mut descriptions = TryVec::with_capacity(description_count)?;
+    let mut descriptions = vec_with_capacity_hint(description_count)?;
 
     let mut iter = src.box_iter();
     while descriptions.len() < description_count {


### PR DESCRIPTION
In many places, the existing code uses `with_capacity` to preallocate a container in preparation as an optimization for parsing the following fields.  In cases where the capacity is read directly from a field in the file and passed to `with_capacity`, it's trivial for an invalid file to trigger a controlled OOM crash by specifying a sufficiently large size.

This is intended to fix the crash mentioned in [BMO 1813063 comment 14](https://bugzilla.mozilla.org/show_bug.cgi?id=1813063#c14), triggered by a fuzzer generated file containing an stsd box reporting 738197505 entries in the sample description table (but only containing 1).

I've replaced each case where we read a u32 or larger field directly from the file and use it as a size hint for `with_capacity` to calls to the trivial wrappers `vec_with_capacity_hint` and `hashmap_with_capacity_hint` that limit the maximum preallocation size to the arbitrary value of 1MB `CAPACITY_HINT_LIMIT`.