### PR TITLE
Fix broken build on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-12]
         rust: [stable]
         release: [true, false]
         experimental: [false]
@@ -30,7 +30,7 @@ jobs:
             rust: nightly
             release: false
             experimental: false
-          - os: macos-10.15
+          - os: macos-12
             rust: nightly
             release: false
             experimental: false


### PR DESCRIPTION
The macos-10.15 target has been deprecated and removed from github, per https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

This updates the build target so to instead tartget macos-12. I've opted to target an explicit version as that's what's done for the other OS targets, rather than using `latest`.