### PR TITLE
Ignore unused trailing data in `mvhd`.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -4517,8 +4517,11 @@ fn read_mvhd<T: Read>(src: &mut BMFFBox<T>) -> Result<MovieHeaderBox> {
         }
         _ => unreachable!("Should have returned Status::MvhdBadVersion"),
     };
-    // Skip remaining fields.
+    // Skip remaining valid fields.
     skip(src, 80)?;
+
+    // Padding could be added in some contents.
+    skip_box_remain(src)?;
     Ok(MovieHeaderBox {
         timescale,
         duration,


### PR DESCRIPTION
This addresses [BMO 1867424](https://bugzilla.mozilla.org/show_bug.cgi?id=1867424), where the linked media contains an unusual `mvhd` with 2 bytes of trailing data.  Since `mvhd` has a fixed set of fields, we were expecting the `mvhd` size to match the spec based on the size of the known fields (108 bytes for this v0 file, v1 would be larger due to 64-bit fields) but the `mvhd` box size is 110 bytes in this file.  To address this, we now skip the remaining unknown bytes based on the box's reported size.