### PR TITLE
Fix import error in dump.rs

### DIFF
--- a/mp4parse_capi/examples/dump.rs
+++ b/mp4parse_capi/examples/dump.rs
@@ -1,5 +1,4 @@
 use log::info;
-use mp4parse::ParseStrictness;
 use mp4parse_capi::*;
 use std::env;
 use std::fs::File;


### PR DESCRIPTION
This fixes the CI error that's been failing on nightly since Feb 19:
```
error: the item `ParseStrictness` is imported redundantly
 --> mp4parse_capi\examples\dump.rs:2:5
  |
2 | use mp4parse::ParseStrictness;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
3 | use mp4parse_capi::*;
  |     ---------------- the item `ParseStrictness` is already imported here
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`
```

I tested locally on with both stable and nightly on macOS.