### PR TITLE
Fix `clippy::legacy_numeric_constants` lint on nightly

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2000,9 +2000,9 @@ enum ConstructionMethod {
 /// Describes a region where a item specified by an `ItemLocationBoxItem` is stored.
 /// The offset is `u64` since that's the maximum possible size and since the relative
 /// nature of `DataBox` means this can still possibly succeed even in the case
-/// that the raw value exceeds std::usize::MAX on platforms where that type is smaller
+/// that the raw value exceeds usize::MAX on platforms where that type is smaller
 /// than u64. However, `len` is stored as a `usize` since no value larger than
-/// `std::usize::MAX` can be used in a successful indexing operation in rust.
+/// `usize::MAX` can be used in a successful indexing operation in rust.
 /// `extent_index` is omitted since it's only used for ConstructionMethod::Item which
 /// is currently not implemented.
 #[derive(Clone, Debug)]
@@ -4338,7 +4338,7 @@ fn parse_mdhd<T: Read>(
 )> {
     let mdhd = read_mdhd(f)?;
     let duration = match mdhd.duration {
-        std::u64::MAX => None,
+        u64::MAX => None,
         duration => Some(TrackScaledTime::<u64>(duration, track.id)),
     };
     if mdhd.timescale == 0 {
@@ -4509,8 +4509,8 @@ fn read_mvhd<T: Read>(src: &mut BMFFBox<T>) -> Result<MovieHeaderBox> {
         1 => be_u64(src)?,
         0 => {
             let d = be_u32(src)?;
-            if d == std::u32::MAX {
-                std::u64::MAX
+            if d == u32::MAX {
+                u64::MAX
             } else {
                 u64::from(d)
             }
@@ -4636,8 +4636,8 @@ fn read_mdhd<T: Read>(src: &mut BMFFBox<T>) -> Result<MediaHeaderBox> {
                 // upcasting, we need to preserve the special all-1s
                 // ("unknown") case by hand.
                 let d = be_u32(src)?;
-                if d == std::u32::MAX {
-                    std::u64::MAX
+                if d == u32::MAX {
+                    u64::MAX
                 } else {
                     u64::from(d)
                 }
@@ -6291,10 +6291,10 @@ mod media_data_box_tests {
 
     #[test]
     fn extent_with_length_which_overflows_usize() {
-        let mdat = DataBox::at_offset(std::u64::MAX - 1, vec![1; 5]);
+        let mdat = DataBox::at_offset(u64::MAX - 1, vec![1; 5]);
         let extent = Extent::WithLength {
-            offset: std::u64::MAX,
-            len: std::usize::MAX,
+            offset: u64::MAX,
+            len: usize::MAX,
         };
 
         assert!(mdat.get(&extent).is_none());
@@ -6304,10 +6304,8 @@ mod media_data_box_tests {
     // because the range end is unbounded, we don't calculate it.
     #[test]
     fn extent_to_end_which_overflows_usize() {
-        let mdat = DataBox::at_offset(std::u64::MAX - 1, vec![1; 5]);
-        let extent = Extent::ToEnd {
-            offset: std::u64::MAX,
-        };
+        let mdat = DataBox::at_offset(u64::MAX - 1, vec![1; 5]);
+        let extent = Extent::ToEnd { offset: u64::MAX };
 
         assert_eq!(mdat.get(&extent), Some(&[1, 1, 1, 1][..]));
     }

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -59,7 +59,7 @@ where
         BoxSize::Long(size) => assert_eq!(size, section.size()),
         BoxSize::Auto => {
             assert!(
-                section.size() <= u64::from(u32::max_value()),
+                section.size() <= u64::from(u32::MAX),
                 "Tried to use a long box with BoxSize::Auto"
             );
             box_size.set_const(section.size());
@@ -335,7 +335,7 @@ fn read_mdhd_unknown_duration() {
         s.B32(0)
             .B32(0)
             .B32(1234) // timescale
-            .B32(::std::u32::MAX) // duration
+            .B32(u32::MAX) // duration
             .B32(0)
     });
     let mut iter = super::BoxIter::new(&mut stream);
@@ -344,7 +344,7 @@ fn read_mdhd_unknown_duration() {
     assert_eq!(stream.head.size, 32);
     let parsed = super::read_mdhd(&mut stream).unwrap();
     assert_eq!(parsed.timescale, 1234);
-    assert_eq!(parsed.duration, ::std::u64::MAX);
+    assert_eq!(parsed.duration, u64::MAX);
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn read_mvhd_unknown_duration() {
         s.B32(0)
             .B32(0)
             .B32(1234)
-            .B32(::std::u32::MAX)
+            .B32(u32::MAX)
             .append_repeated(0, 80)
     });
     let mut iter = super::BoxIter::new(&mut stream);
@@ -420,7 +420,7 @@ fn read_mvhd_unknown_duration() {
     assert_eq!(stream.head.size, 108);
     let parsed = super::read_mvhd(&mut stream).unwrap();
     assert_eq!(parsed.timescale, 1234);
-    assert_eq!(parsed.duration, ::std::u64::MAX);
+    assert_eq!(parsed.duration, u64::MAX);
 }
 
 #[test]
@@ -1361,6 +1361,6 @@ fn read_to_end_() {
 
 #[test]
 fn read_to_end_oom() {
-    let mut src = b"1234567890".take(std::isize::MAX.try_into().expect("isize < u64"));
+    let mut src = b"1234567890".take(isize::MAX.try_into().expect("isize < u64"));
     assert!(src.read_into_try_vec().is_err());
 }

--- a/mp4parse/tests/overflow.rs
+++ b/mp4parse/tests/overflow.rs
@@ -5,11 +5,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #[test]
+#[allow(arithmetic_overflow)]
 #[should_panic(expected = "attempt to add with overflow")]
 fn overflow_protection() {
-    let edge = u32::max_value();
+    let edge = u32::MAX;
     assert_eq!(0u32, edge + 1);
 
-    let edge = u64::max_value();
+    let edge = u64::MAX;
     assert_eq!(0u64, edge + 1);
 }

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -439,7 +439,7 @@ pub struct Mp4parseIo {
 
 impl Read for Mp4parseIo {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if buf.len() > isize::max_value() as usize {
+        if buf.len() > isize::MAX as usize {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "buf length overflow in Mp4parseIo Read impl",
@@ -583,7 +583,7 @@ pub unsafe extern "C" fn mp4parse_get_track_count(
     let context = (*parser).context();
 
     // Make sure the track count fits in a u32.
-    if context.tracks.len() > u32::max_value() as usize {
+    if context.tracks.len() > u32::MAX as usize {
         return Mp4parseStatus::Invalid;
     }
     *count = context.tracks.len() as u32;
@@ -763,7 +763,7 @@ fn get_track_audio_info(
 
         match audio.codec_specific {
             AudioCodecSpecific::ES_Descriptor(ref esds) => {
-                if esds.codec_esds.len() > std::u32::MAX as usize {
+                if esds.codec_esds.len() > u32::MAX as usize {
                     return Err(Mp4parseStatus::Invalid);
                 }
                 sample_info.extra_data.length = esds.codec_esds.len();
@@ -802,7 +802,7 @@ fn get_track_audio_info(
                     Ok(_) => {
                         opus_header.insert(track_index, v)?;
                         if let Some(v) = opus_header.get(&track_index) {
-                            if v.len() > std::u32::MAX as usize {
+                            if v.len() > u32::MAX as usize {
                                 return Err(Mp4parseStatus::Invalid);
                             }
                             sample_info.codec_specific_config.length = v.len();
@@ -849,7 +849,7 @@ fn get_track_audio_info(
                 sample_info.protected_data.skip_byte_block =
                     tenc.skip_byte_block_count.unwrap_or(0);
                 if let Some(ref iv_vec) = tenc.constant_iv {
-                    if iv_vec.len() > std::u32::MAX as usize {
+                    if iv_vec.len() > u32::MAX as usize {
                         return Err(Mp4parseStatus::Invalid);
                     }
                     sample_info.protected_data.constant_iv.set_data(iv_vec);
@@ -864,7 +864,7 @@ fn get_track_audio_info(
         .insert(track_index, audio_sample_infos)?;
     match parser.audio_track_sample_descriptions.get(&track_index) {
         Some(sample_info) => {
-            if sample_info.len() > std::u32::MAX as usize {
+            if sample_info.len() > u32::MAX as usize {
                 // Should never happen due to upper limits on number of sample
                 // descriptions a track can have, but lets be safe.
                 return Err(Mp4parseStatus::Invalid);
@@ -1017,7 +1017,7 @@ fn mp4parse_get_track_video_info_safe(
                 sample_info.protected_data.skip_byte_block =
                     tenc.skip_byte_block_count.unwrap_or(0);
                 if let Some(ref iv_vec) = tenc.constant_iv {
-                    if iv_vec.len() > std::u32::MAX as usize {
+                    if iv_vec.len() > u32::MAX as usize {
                         return Err(Mp4parseStatus::Invalid);
                     }
                     sample_info.protected_data.constant_iv.set_data(iv_vec);
@@ -1032,7 +1032,7 @@ fn mp4parse_get_track_video_info_safe(
         .insert(track_index, video_sample_infos)?;
     match parser.video_track_sample_descriptions.get(&track_index) {
         Some(sample_info) => {
-            if sample_info.len() > std::u32::MAX as usize {
+            if sample_info.len() > u32::MAX as usize {
                 // Should never happen due to upper limits on number of sample
                 // descriptions a track can have, but lets be safe.
                 return Err(Mp4parseStatus::Invalid);
@@ -1185,7 +1185,7 @@ fn mp4parse_avif_get_info_safe(context: &AvifContext) -> mp4parse::Result<Mp4par
         };
 
         let (loop_mode, loop_count) = match color_track.tkhd.as_ref().map(|tkhd| tkhd.duration) {
-            Some(movie_duration) if movie_duration == std::u64::MAX => {
+            Some(movie_duration) if movie_duration == u64::MAX => {
                 (Mp4parseAvifLoopMode::LoopInfinitely, 0)
             }
             Some(movie_duration) => match color_track.looped {

--- a/mp4parse_capi/tests/test_avis.rs
+++ b/mp4parse_capi/tests/test_avis.rs
@@ -57,7 +57,7 @@ fn check_loop_count(path: &str, expected_loop_count: i64) {
         Mp4parseAvifLoopMode::LoopByCount => {
             assert_eq!(info.loop_count.to_i64(), Some(expected_loop_count))
         }
-        Mp4parseAvifLoopMode::LoopInfinitely => assert_eq!(expected_loop_count, std::i64::MIN),
+        Mp4parseAvifLoopMode::LoopInfinitely => assert_eq!(expected_loop_count, i64::MIN),
     }
 
     unsafe { mp4parse_avif_free(parser) };
@@ -95,7 +95,7 @@ fn loop_four_times_due_to_ceiling() {
 
 #[test]
 fn loop_forever() {
-    check_loop_count("tests/loop_forever.avif", std::i64::MIN);
+    check_loop_count("tests/loop_forever.avif", i64::MIN);
 }
 
 #[test]

--- a/mp4parse_capi/tests/test_sample_table.rs
+++ b/mp4parse_capi/tests/test_sample_table.rs
@@ -156,7 +156,7 @@ fn parse_sample_table_with_elst() {
         assert_eq!(track_info.track_type, Mp4parseTrackType::Audio);
 
         // Check audio sample table
-        let mut is_fragmented_file: u8 = std::u8::MAX;
+        let mut is_fragmented_file: u8 = u8::MAX;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(is_fragmented_file, 0);
@@ -225,7 +225,7 @@ fn parse_sample_table_with_negative_ctts() {
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(track_info.track_type, Mp4parseTrackType::Video);
 
-        let mut is_fragmented_file: u8 = std::u8::MAX;
+        let mut is_fragmented_file: u8 = u8::MAX;
         rv = mp4parse_is_fragmented(parser, track_info.track_id, &mut is_fragmented_file);
         assert_eq!(rv, Mp4parseStatus::Ok);
         assert_eq!(is_fragmented_file, 0);


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants

Hopefully this fixes https://github.com/mozilla/mp4parse-rust/actions/runs/8598206617/job/23558557224
I couldn't reproduce it locally, but the fix didn't seem to break either stable or nightly locally either, so I figure if this passes CI, it should fix the issue.