### PR TITLE
Don't fail when the wave atom contains different atoms than esds

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -5737,9 +5737,15 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
                 codec_specific = Some(AudioCodecSpecific::ALACSpecificBox(alac));
             }
             BoxType::QTWaveAtom => {
-                let qt_esds = read_qt_wave_atom(&mut b)?;
-                codec_type = qt_esds.audio_codec;
-                codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
+                match read_qt_wave_atom(&mut b) {
+                    Ok(qt_esds) => {
+                        codec_type = qt_esds.audio_codec;
+                        codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
+                    },
+                    Err(e) => {
+                        warn!("Failed to parse wave atom: {e:?}");
+                    }
+                }
             }
             BoxType::ProtectionSchemeInfoBox => {
                 if name != BoxType::ProtectedAudioSampleEntry {


### PR DESCRIPTION
This PR changes the behavior of the `wave` atom parsing such that it doesn't fail when that atom contains unknown (not implemented) boxes. 
Example file where this happens: https://drive.google.com/file/d/1NbX5QlSR8BLuHK2uj0lm14yJ0DJ3jT4H/view?usp=sharing

Instead of failing to parse the entire file, just skip that box and leave `codec_specific` as `None`