### PR TITLE
Update fallible_collections

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -29,7 +29,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-fallible_collections = { version = "0.4", features = ["std_io"] }
+fallible_collections = { version = "0.5.1", features = ["std_io"] }
 num-traits = "0.2.14"
 log = "0.4"
 static_assertions = "1.1.0"


### PR DESCRIPTION
So that this crate doesn't (transitively) depend on the aging hashbrown 0.13 series.