### PR TITLE
Update fallible_collections from 0.4 to 0.5

### DIFF
--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -29,7 +29,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 [dependencies]
 byteorder = "1.2.1"
 bitreader = { version = "0.3.2" }
-fallible_collections = { version = "0.4", features = ["std_io"] }
+fallible_collections = { version = "0.5", features = ["std_io"] }
 num-traits = "0.2.14"
 log = "0.4"
 static_assertions = "1.1.0"

--- a/mp4parse_capi/Cargo.toml
+++ b/mp4parse_capi/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = { repository = "https://github.com/mozilla/mp4parse-rust" }
 
 [dependencies]
 byteorder = "1.2.1"
-fallible_collections = { version = "0.4", features = ["std_io"] }
+fallible_collections = { version = "0.5", features = ["std_io"] }
 log = "0.4"
 mp4parse = { version = "0.17.0", path = "../mp4parse", features = ["unstable-api"] }
 num-traits = "0.2.14"


### PR DESCRIPTION
This is a near-duplicate of https://github.com/mozilla/mp4parse-rust/pull/421, but it updates *both* `fallible_collections` dependencies.

I confirmed that `cargo test --workspace` still succeeds.