### PR TITLE
fallback to 'map_or' to fix Linux build error.

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -4734,7 +4734,7 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
 
     if counts
         .checked_mul(8)
-        .is_none_or(|bytes| u64::from(bytes) > src.bytes_left())
+        .map_or(true, |bytes| u64::from(bytes) > src.bytes_left())
     {
         return Status::CttsBadSize.into();
     }


### PR DESCRIPTION
using `is_none_or` causes [a build error](https://treeherder.mozilla.org/logviewer?job_id=493126982&repo=try&lineNumber=81467) on Linux, full push can be seen [here](https://treeherder.mozilla.org/jobs?repo=try&revision=e2ee1d91178aef400be793bb2a648aa43de36b30&selectedTaskRun=KcQZQi2nTQyGM9yTAIECkw.0).