### PR TITLE
Allow multiple DecoderSpecificInfo entries in non-strict mode

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -2417,7 +2417,7 @@ pub fn read_avif<T: Read>(f: &mut T, strictness: ParseStrictness) -> Result<Avif
                 if image_sequence.is_some() {
                     return Status::MoovBadQuantity.into();
                 }
-                image_sequence = Some(read_moov(&mut b, None)?);
+                image_sequence = Some(read_moov(&mut b, None, strictness)?);
             }
             BoxType::MediaDataBox => {
                 let file_offset = b.offset();
@@ -4058,7 +4058,7 @@ fn read_iloc<T: Read>(src: &mut BMFFBox<T>) -> Result<TryHashMap<ItemId, ItemLoc
 }
 
 /// Read the contents of a box, including sub boxes.
-pub fn read_mp4<T: Read>(f: &mut T) -> Result<MediaContext> {
+pub fn read_mp4<T: Read>(f: &mut T, strictness: ParseStrictness) -> Result<MediaContext> {
     let mut context = None;
     let mut found_ftyp = false;
     // TODO(kinetik): Top-level parsing should handle zero-sized boxes
@@ -4087,7 +4087,7 @@ pub fn read_mp4<T: Read>(f: &mut T) -> Result<MediaContext> {
                 debug!("{:?}", ftyp);
             }
             BoxType::MovieBox => {
-                context = Some(read_moov(&mut b, context)?);
+                context = Some(read_moov(&mut b, context, strictness)?);
             }
             #[cfg(feature = "meta-xml")]
             BoxType::MetadataBox => {
@@ -4133,7 +4133,11 @@ fn parse_mvhd<T: Read>(f: &mut BMFFBox<T>) -> Result<Option<MediaTimeScale>> {
 /// Note that despite the spec indicating "exactly one" moov box should exist at
 /// the file container level, we support reading and merging multiple moov boxes
 /// such as with tests/test_case_1185230.mp4.
-fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: Option<MediaContext>) -> Result<MediaContext> {
+fn read_moov<T: Read>(
+    f: &mut BMFFBox<T>,
+    context: Option<MediaContext>,
+    strictness: ParseStrictness,
+) -> Result<MediaContext> {
     let MediaContext {
         mut timescale,
         mut tracks,
@@ -4152,7 +4156,7 @@ fn read_moov<T: Read>(f: &mut BMFFBox<T>, context: Option<MediaContext>) -> Resu
             }
             BoxType::TrackBox => {
                 let mut track = Track::new(tracks.len());
-                read_trak(&mut b, &mut track)?;
+                read_trak(&mut b, &mut track, strictness)?;
                 tracks.push(track)?;
             }
             BoxType::MovieExtendsBox => {
@@ -4262,7 +4266,11 @@ fn read_mehd<T: Read>(src: &mut BMFFBox<T>) -> Result<MediaScaledTime> {
 
 /// Parse a Track Box
 /// See ISOBMFF (ISO 14496-12:2020) § 8.3.1.
-fn read_trak<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
+fn read_trak<T: Read>(
+    f: &mut BMFFBox<T>,
+    track: &mut Track,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let mut iter = f.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
@@ -4273,7 +4281,7 @@ fn read_trak<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
                 debug!("{:?}", tkhd);
             }
             BoxType::EditBox => read_edts(&mut b, track)?,
-            BoxType::MediaBox => read_mdia(&mut b, track)?,
+            BoxType::MediaBox => read_mdia(&mut b, track, strictness)?,
             BoxType::TrackReferenceBox => track.tref = Some(read_tref(&mut b)?),
             _ => skip_box_content(&mut b)?,
         };
@@ -4346,7 +4354,11 @@ fn parse_mdhd<T: Read>(
     Ok((mdhd, duration, timescale))
 }
 
-fn read_mdia<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
+fn read_mdia<T: Read>(
+    f: &mut BMFFBox<T>,
+    track: &mut Track,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let mut iter = f.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
@@ -4369,7 +4381,7 @@ fn read_mdia<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
                 }
                 debug!("{:?}", hdlr);
             }
-            BoxType::MediaInformationBox => read_minf(&mut b, track)?,
+            BoxType::MediaInformationBox => read_minf(&mut b, track, strictness)?,
             _ => skip_box_content(&mut b)?,
         };
         check_parser_state!(b.content);
@@ -4403,11 +4415,15 @@ fn read_tref_auxl<T: Read>(f: &mut BMFFBox<T>) -> Result<TrackReference> {
     Ok(TrackReference { track_ids })
 }
 
-fn read_minf<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
+fn read_minf<T: Read>(
+    f: &mut BMFFBox<T>,
+    track: &mut Track,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let mut iter = f.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
-            BoxType::SampleTableBox => read_stbl(&mut b, track)?,
+            BoxType::SampleTableBox => read_stbl(&mut b, track, strictness)?,
             _ => skip_box_content(&mut b)?,
         };
         check_parser_state!(b.content);
@@ -4415,12 +4431,16 @@ fn read_minf<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
     Ok(())
 }
 
-fn read_stbl<T: Read>(f: &mut BMFFBox<T>, track: &mut Track) -> Result<()> {
+fn read_stbl<T: Read>(
+    f: &mut BMFFBox<T>,
+    track: &mut Track,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let mut iter = f.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
             BoxType::SampleDescriptionBox => {
-                let stsd = read_stsd(&mut b, track)?;
+                let stsd = read_stsd(&mut b, track, strictness)?;
                 debug!("{:?}", stsd);
                 track.stsd = Some(stsd);
             }
@@ -4942,7 +4962,11 @@ fn read_flac_metadata<T: Read>(src: &mut BMFFBox<T>) -> Result<FLACMetadataBlock
 }
 
 /// See MPEG-4 Systems (ISO 14496-1:2010) § 7.2.6.5
-fn find_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
+fn find_descriptor(
+    data: &[u8],
+    esds: &mut ES_Descriptor,
+    strictness: ParseStrictness,
+) -> Result<()> {
     // Tags for elementary stream description
     const ESDESCR_TAG: u8 = 0x03;
     const DECODER_CONFIG_TAG: u8 = 0x04;
@@ -4982,13 +5006,13 @@ fn find_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 
         match tag {
             ESDESCR_TAG => {
-                read_es_descriptor(descriptor, esds)?;
+                read_es_descriptor(descriptor, esds, strictness)?;
             }
             DECODER_CONFIG_TAG => {
-                read_dc_descriptor(descriptor, esds)?;
+                read_dc_descriptor(descriptor, esds, strictness)?;
             }
             DECODER_SPECIFIC_TAG => {
-                read_ds_descriptor(descriptor, esds)?;
+                read_ds_descriptor(descriptor, esds, strictness)?;
             }
             _ => {
                 debug!("Unsupported descriptor, tag {}", tag);
@@ -5014,7 +5038,11 @@ fn get_audio_object_type(bit_reader: &mut BitReader) -> Result<u16> {
 }
 
 /// See MPEG-4 Systems (ISO 14496-1:2010) § 7.2.6.7 and probably 14496-3 somewhere?
-fn read_ds_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
+fn read_ds_descriptor(
+    data: &[u8],
+    esds: &mut ES_Descriptor,
+    _strictness: ParseStrictness,
+) -> Result<()> {
     #[cfg(feature = "mp4v")]
     // Check if we are in a Visual esda Box.
     if esds.video_codec != CodecType::Unknown {
@@ -5191,7 +5219,11 @@ fn read_surround_channel_count(bit_reader: &mut BitReader, channels: u8) -> Resu
 }
 
 /// See MPEG-4 Systems (ISO 14496-1:2010) § 7.2.6.6
-fn read_dc_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
+fn read_dc_descriptor(
+    data: &[u8],
+    esds: &mut ES_Descriptor,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let des = &mut Cursor::new(data);
     let object_profile = des.read_u8()?;
 
@@ -5207,7 +5239,11 @@ fn read_dc_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     skip(des, 12)?;
 
     if data.len().to_u64() > des.position() {
-        find_descriptor(&data[des.position().try_into()?..data.len()], esds)?;
+        find_descriptor(
+            &data[des.position().try_into()?..data.len()],
+            esds,
+            strictness,
+        )?;
     }
 
     esds.audio_codec = match object_profile {
@@ -5225,7 +5261,11 @@ fn read_dc_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
 }
 
 /// See MPEG-4 Systems (ISO 14496-1:2010) § 7.2.6.5
-fn read_es_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
+fn read_es_descriptor(
+    data: &[u8],
+    esds: &mut ES_Descriptor,
+    strictness: ParseStrictness,
+) -> Result<()> {
     let des = &mut Cursor::new(data);
 
     skip(des, 2)?;
@@ -5246,20 +5286,24 @@ fn read_es_descriptor(data: &[u8], esds: &mut ES_Descriptor) -> Result<()> {
     }
 
     if data.len().to_u64() > des.position() {
-        find_descriptor(&data[des.position().try_into()?..data.len()], esds)?;
+        find_descriptor(
+            &data[des.position().try_into()?..data.len()],
+            esds,
+            strictness,
+        )?;
     }
 
     Ok(())
 }
 
 /// See MP4 (ISO 14496-14:2020) § 6.7.2
-fn read_esds<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
+fn read_esds<T: Read>(src: &mut BMFFBox<T>, strictness: ParseStrictness) -> Result<ES_Descriptor> {
     let (_, _) = read_fullbox_extra(src)?;
 
     let esds_array = read_buf(src, src.bytes_left())?;
 
     let mut es_data = ES_Descriptor::default();
-    find_descriptor(&esds_array, &mut es_data)?;
+    find_descriptor(&esds_array, &mut es_data, strictness)?;
 
     es_data.codec_esds = esds_array;
 
@@ -5558,7 +5602,7 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
                 {
                     // Read ES_Descriptor inside an esds box.
                     // See ISOBMFF (ISO 14496-1:2010) § 7.2.6.5
-                    let esds = read_esds(&mut b)?;
+                    let esds = read_esds(&mut b, ParseStrictness::Normal)?;
                     codec_specific =
                         Some(VideoCodecSpecific::ESDSConfig(esds.decoder_specific_data));
                 }
@@ -5621,13 +5665,16 @@ fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
     )
 }
 
-fn read_qt_wave_atom<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
+fn read_qt_wave_atom<T: Read>(
+    src: &mut BMFFBox<T>,
+    strictness: ParseStrictness,
+) -> Result<ES_Descriptor> {
     let mut codec_specific = None;
     let mut iter = src.box_iter();
     while let Some(mut b) = iter.next_box()? {
         match b.head.name {
             BoxType::ESDBox => {
-                let esds = read_esds(&mut b)?;
+                let esds = read_esds(&mut b, strictness)?;
                 codec_specific = Some(esds);
             }
             _ => skip_box_content(&mut b)?,
@@ -5639,7 +5686,10 @@ fn read_qt_wave_atom<T: Read>(src: &mut BMFFBox<T>) -> Result<ES_Descriptor> {
 
 /// Parse an audio description inside an stsd box.
 /// See ISOBMFF (ISO 14496-12:2020) § 12.2.3
-fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry> {
+fn read_audio_sample_entry<T: Read>(
+    src: &mut BMFFBox<T>,
+    strictness: ParseStrictness,
+) -> Result<SampleEntry> {
     let name = src.get_header().name;
 
     // Skip uninteresting fields.
@@ -5713,7 +5763,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
                 {
                     return Status::StsdBadAudioSampleEntry.into();
                 }
-                let esds = read_esds(&mut b)?;
+                let esds = read_esds(&mut b, strictness)?;
                 codec_type = esds.audio_codec;
                 codec_specific = Some(AudioCodecSpecific::ES_Descriptor(esds));
             }
@@ -5746,7 +5796,7 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
                 codec_specific = Some(AudioCodecSpecific::ALACSpecificBox(alac));
             }
             BoxType::QTWaveAtom => {
-                let qt_esds = read_qt_wave_atom(&mut b)?;
+                let qt_esds = read_qt_wave_atom(&mut b, strictness)?;
                 codec_type = qt_esds.audio_codec;
                 codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
             }
@@ -5799,7 +5849,11 @@ fn read_audio_sample_entry<T: Read>(src: &mut BMFFBox<T>) -> Result<SampleEntry>
 /// Parse a stsd box.
 /// See ISOBMFF (ISO 14496-12:2020) § 8.5.2
 /// See MP4 (ISO 14496-14:2020) § 6.7.2
-fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &Track) -> Result<SampleDescriptionBox> {
+fn read_stsd<T: Read>(
+    src: &mut BMFFBox<T>,
+    track: &Track,
+    strictness: ParseStrictness,
+) -> Result<SampleDescriptionBox> {
     let (_, flags) = read_fullbox_extra(src)?;
 
     if flags != 0 {
@@ -5819,7 +5873,7 @@ fn read_stsd<T: Read>(src: &mut BMFFBox<T>, track: &Track) -> Result<SampleDescr
                 TrackType::Video => read_video_sample_entry(&mut b),
                 TrackType::Picture => read_video_sample_entry(&mut b),
                 TrackType::AuxiliaryVideo => read_video_sample_entry(&mut b),
-                TrackType::Audio => read_audio_sample_entry(&mut b),
+                TrackType::Audio => read_audio_sample_entry(&mut b, strictness),
                 TrackType::Metadata => Err(Error::Unsupported("metadata track")),
                 TrackType::Unknown => Err(Error::Unsupported("unknown track type")),
             };

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -200,7 +200,7 @@ pub enum Status {
     ElstBadVersion,
     EsdsBadAudioSampleEntry,
     EsdsBadDescriptor,
-    EsdsDecSpecificIntoTagQuantity,
+    EsdsDecSpecificInfoTagQuantity,
     FtypBadSize,
     FtypNotFirst,
     HdlrNameNoNul,
@@ -514,7 +514,7 @@ impl From<Status> for &str {
             Status::EsdsBadDescriptor => {
                 "Invalid descriptor."
             }
-            Status::EsdsDecSpecificIntoTagQuantity => {
+            Status::EsdsDecSpecificInfoTagQuantity => {
                 "There can be only one DecSpecificInfoTag descriptor"
             }
             Status::FtypBadSize => {
@@ -5041,7 +5041,7 @@ fn get_audio_object_type(bit_reader: &mut BitReader) -> Result<u16> {
 fn read_ds_descriptor(
     data: &[u8],
     esds: &mut ES_Descriptor,
-    _strictness: ParseStrictness,
+    strictness: ParseStrictness,
 ) -> Result<()> {
     #[cfg(feature = "mp4v")]
     // Check if we are in a Visual esda Box.
@@ -5198,7 +5198,10 @@ fn read_ds_descriptor(
             esds.audio_sample_rate = Some(sample_frequency_value);
             esds.audio_channel_count = Some(channel_counts);
             if !esds.decoder_specific_data.is_empty() {
-                return Status::EsdsDecSpecificIntoTagQuantity.into();
+                fail_with_status_if(
+                    strictness == ParseStrictness::Strict,
+                    Status::EsdsDecSpecificInfoTagQuantity,
+                )?;
             }
             esds.decoder_specific_data.extend_from_slice(data)?;
 

--- a/mp4parse/src/tests.rs
+++ b/mp4parse/src/tests.rs
@@ -211,7 +211,7 @@ fn read_truncated_ftyp() {
             .B32(0) // minor version
             .append_bytes(b"isom")
     });
-    match read_mp4(&mut stream) {
+    match read_mp4(&mut stream, ParseStrictness::Normal) {
         Err(Error::UnexpectedEOF) => (),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -649,7 +649,7 @@ fn read_flac() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let r = super::read_audio_sample_entry(&mut stream);
+    let r = super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal);
     assert!(r.is_ok());
 }
 
@@ -740,7 +740,7 @@ fn read_opus() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let r = super::read_audio_sample_entry(&mut stream);
+    let r = super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal);
     assert!(r.is_ok());
 }
 
@@ -830,7 +830,7 @@ fn read_alac() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let r = super::read_audio_sample_entry(&mut stream);
+    let r = super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal);
     assert!(r.is_ok());
 }
 
@@ -852,7 +852,7 @@ fn esds_limit() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    match super::read_audio_sample_entry(&mut stream) {
+    match super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal) {
         Err(Error::UnexpectedEOF) => (),
         Ok(_) => panic!("expected an error result"),
         _ => panic!("expected a different error result"),
@@ -963,7 +963,8 @@ fn skip_padding_in_stsd() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    super::read_stsd(&mut stream, &super::Track::new(0)).expect("fail to skip padding: stsd");
+    super::read_stsd(&mut stream, &super::Track::new(0), ParseStrictness::Normal)
+        .expect("fail to skip padding: stsd");
 }
 
 #[test]
@@ -1000,8 +1001,8 @@ fn read_qt_wave_atom() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let sample_entry =
-        super::read_audio_sample_entry(&mut stream).expect("fail to read qt wave atom");
+    let sample_entry = super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal)
+        .expect("fail to read qt wave atom");
     match sample_entry {
         super::SampleEntry::Audio(sample_entry) => {
             assert_eq!(sample_entry.codec_type, super::CodecType::MP3)
@@ -1025,7 +1026,7 @@ fn read_descriptor_80() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let es = super::read_esds(&mut stream).unwrap();
+    let es = super::read_esds(&mut stream, ParseStrictness::Normal).unwrap();
 
     assert_eq!(es.audio_codec, super::CodecType::AAC);
     assert_eq!(es.audio_object_type, Some(2));
@@ -1052,7 +1053,7 @@ fn read_esds() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let es = super::read_esds(&mut stream).unwrap();
+    let es = super::read_esds(&mut stream, ParseStrictness::Normal).unwrap();
 
     assert_eq!(es.audio_codec, super::CodecType::AAC);
     assert_eq!(es.audio_object_type, Some(2));
@@ -1081,7 +1082,7 @@ fn read_esds_aac_type5() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let es = super::read_esds(&mut stream).unwrap();
+    let es = super::read_esds(&mut stream, ParseStrictness::Normal).unwrap();
 
     assert_eq!(es.audio_codec, super::CodecType::AAC);
     assert_eq!(es.audio_object_type, Some(2));
@@ -1110,7 +1111,7 @@ fn read_esds_mpeg2_aac_lc() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let es = super::read_esds(&mut stream).unwrap();
+    let es = super::read_esds(&mut stream, ParseStrictness::Normal).unwrap();
 
     assert_eq!(es.audio_codec, super::CodecType::AAC);
     assert_eq!(es.audio_object_type, Some(2));
@@ -1179,7 +1180,7 @@ fn read_esds_one_byte_extension_descriptor() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let es = super::read_esds(&mut stream).unwrap();
+    let es = super::read_esds(&mut stream, ParseStrictness::Normal).unwrap();
 
     assert_eq!(es.audio_codec, super::CodecType::AAC);
     assert_eq!(es.audio_object_type, Some(2));
@@ -1199,7 +1200,7 @@ fn read_esds_byte_extension_descriptor() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    match super::read_esds(&mut stream) {
+    match super::read_esds(&mut stream, ParseStrictness::Normal) {
         Ok(_) => (),
         _ => panic!("fail to parse descriptor extension byte length"),
     }
@@ -1220,8 +1221,8 @@ fn read_f4v_stsd() {
 
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    let sample_entry =
-        super::read_audio_sample_entry(&mut stream).expect("failed to read f4v stsd atom");
+    let sample_entry = super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal)
+        .expect("failed to read f4v stsd atom");
     match sample_entry {
         super::SampleEntry::Audio(sample_entry) => {
             assert_eq!(sample_entry.codec_type, super::CodecType::MP3)
@@ -1269,7 +1270,7 @@ fn unknown_audio_sample_entry() {
     });
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
-    match super::read_audio_sample_entry(&mut stream) {
+    match super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal) {
         Ok(super::SampleEntry::Unknown) => (),
         _ => panic!("expected a different error result"),
     }
@@ -1291,7 +1292,7 @@ fn read_esds_invalid_descriptor() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    match super::read_esds(&mut stream) {
+    match super::read_esds(&mut stream, ParseStrictness::Normal) {
         Err(Error::InvalidData(s)) => assert_eq!(s, Status::EsdsBadDescriptor),
         _ => panic!("unexpected result with invalid descriptor"),
     }
@@ -1311,7 +1312,7 @@ fn read_esds_redundant_descriptor() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    match super::read_esds(&mut stream) {
+    match super::read_esds(&mut stream, ParseStrictness::Normal) {
         Ok(esds) => assert_eq!(esds.audio_codec, super::CodecType::AAC),
         _ => panic!("unexpected result with invalid descriptor"),
     }
@@ -1334,7 +1335,8 @@ fn read_stsd_lpcm() {
     let mut iter = super::BoxIter::new(&mut stream);
     let mut stream = iter.next_box().unwrap().unwrap();
 
-    let sample_entry = super::read_audio_sample_entry(&mut stream).unwrap();
+    let sample_entry =
+        super::read_audio_sample_entry(&mut stream, ParseStrictness::Normal).unwrap();
 
     match sample_entry {
         #[allow(clippy::float_cmp)] // The float comparison below is valid and intended.

--- a/mp4parse/tests/public.rs
+++ b/mp4parse/tests/public.rs
@@ -243,7 +243,7 @@ fn public_api() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     assert_eq!(context.timescale, Some(mp4::MediaTimeScale(1000)));
     for track in context.tracks {
         match track.track_type {
@@ -373,7 +373,7 @@ fn public_metadata() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     let udta = context
         .userdata
         .expect("didn't find udta")
@@ -439,7 +439,7 @@ fn public_metadata_gnre() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     let udta = context
         .userdata
         .expect("didn't find udta")
@@ -504,7 +504,7 @@ fn public_invalid_metadata() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     // Should have userdata.
     assert!(context.userdata.is_some());
     // But it should contain an error.
@@ -547,7 +547,7 @@ fn public_audio_tenc() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -605,7 +605,7 @@ fn public_video_cenc() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -677,7 +677,7 @@ fn public_audio_cbcs() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         assert_eq!(stsd.descriptions.len(), 2);
@@ -758,7 +758,7 @@ fn public_video_cbcs() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         assert_eq!(stsd.descriptions.len(), 2);
@@ -816,7 +816,7 @@ fn public_video_av1() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         // track part
         assert_eq!(track.duration, Some(mp4::TrackScaledTime(512, 0)));
@@ -863,7 +863,7 @@ fn public_video_av1() {
 #[test]
 fn public_mp4_bug_1185230() {
     let input = &mut File::open("tests/test_case_1185230.mp4").expect("Unknown file");
-    let context = mp4::read_mp4(input).expect("read_mp4 failed");
+    let context = mp4::read_mp4(input, ParseStrictness::Normal).expect("read_mp4 failed");
     let number_video_tracks = context
         .tracks
         .iter()
@@ -882,7 +882,10 @@ fn public_mp4_bug_1185230() {
 fn public_mp4_ctts_overflow() {
     let input = &mut File::open("tests/clusterfuzz-testcase-minimized-mp4-6093954524250112")
         .expect("Unknown file");
-    assert_eq!(Status::from(mp4::read_mp4(input)), Status::CttsBadSize);
+    assert_eq!(
+        Status::from(mp4::read_mp4(input, ParseStrictness::Normal)),
+        Status::CttsBadSize
+    );
 }
 
 #[test]
@@ -1427,7 +1430,7 @@ fn public_video_h263() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -1453,7 +1456,7 @@ fn public_video_hevc() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -1479,7 +1482,7 @@ fn public_parse_pasp_h264() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -1509,7 +1512,7 @@ fn public_audio_amrnb() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -1534,7 +1537,7 @@ fn public_audio_amrwb() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let a = match stsd.descriptions.first().expect("expected a SampleEntry") {
@@ -1559,7 +1562,7 @@ fn public_video_mp4v() {
     fd.read_to_end(&mut buf).expect("File error");
 
     let mut c = Cursor::new(&buf);
-    let context = mp4::read_mp4(&mut c).expect("read_mp4 failed");
+    let context = mp4::read_mp4(&mut c, ParseStrictness::Normal).expect("read_mp4 failed");
     for track in context.tracks {
         let stsd = track.stsd.expect("expected an stsd");
         let v = match stsd.descriptions.first().expect("expected a SampleEntry") {

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -391,8 +391,8 @@ impl ContextParser for Mp4parseParser {
         }
     }
 
-    fn read<T: Read>(io: &mut T, _strictness: ParseStrictness) -> mp4parse::Result<Self::Context> {
-        let r = mp4parse::read_mp4(io);
+    fn read<T: Read>(io: &mut T, strictness: ParseStrictness) -> mp4parse::Result<Self::Context> {
+        let r = mp4parse::read_mp4(io, strictness);
         log::debug!("mp4parse::read_mp4 -> {:?}", r);
         r
     }


### PR DESCRIPTION
This is a fix for [BMO# 1936124](https://bugzilla.mozilla.org/show_bug.cgi?id=1936124).