### PR TITLE
Make nightly clippy happy with std::io::Error::other

### DIFF
--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -442,8 +442,7 @@ pub struct Mp4parseIo {
 impl Read for Mp4parseIo {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         if buf.len() > isize::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 "buf length overflow in Mp4parseIo Read impl",
             ));
         }
@@ -451,8 +450,7 @@ impl Read for Mp4parseIo {
         if rv >= 0 {
             Ok(rv as usize)
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(std::io::Error::other(
                 "I/O error in Mp4parseIo Read impl",
             ))
         }


### PR DESCRIPTION
Just to turn your CI green: https://github.com/mozilla/mp4parse-rust/actions/runs/14466753222/job/40570827441

Not sure about your MSRV, but FYI `std::io::Error::other` was added 1.74.