### PR TITLE
Also allow padding at the end of ctts boxes

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -4760,7 +4760,8 @@ fn read_ctts<T: Read>(src: &mut BMFFBox<T>) -> Result<CompositionOffsetBox> {
         })?;
     }
 
-    check_parser_state!(src.content);
+    // Padding could be added in some contents.
+    skip_box_remain(src)?;
 
     Ok(CompositionOffsetBox { samples: offsets })
 }


### PR DESCRIPTION
This was necessary to successfully parse the following file:
https://www.mea-culpa.at/02_videos/gesch_175_580x432px_12fps_300kbit.f4v

It has 7080 bytes of extra stuff in its `ctts` box after the given number of sample counts and offsets.

Other media players and demuxers (like VLC or MP4Box.js) had no problem with this particular file.

I copied the call and comment from other similar box reader functions nearby.