### PR TITLE
Allow unknown codecs when the ParseStrictness is not Strict

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -5515,7 +5515,10 @@ fn read_hdlr<T: Read>(src: &mut BMFFBox<T>, strictness: ParseStrictness) -> Resu
 }
 
 /// Parse an video description inside an stsd box.
-fn read_video_sample_entry<T: Read>(src: &mut BMFFBox<T>, strictness: ParseStrictness) -> Result<SampleEntry> {
+fn read_video_sample_entry<T: Read>(
+    src: &mut BMFFBox<T>,
+    strictness: ParseStrictness,
+) -> Result<SampleEntry> {
     let name = src.get_header().name;
     let codec_type = match name {
         BoxType::AVCSampleEntry | BoxType::AVC3SampleEntry => CodecType::H264,

--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -5818,11 +5818,15 @@ fn read_audio_sample_entry<T: Read>(
                 codec_type = CodecType::ALAC;
                 codec_specific = Some(AudioCodecSpecific::ALACSpecificBox(alac));
             }
-            BoxType::QTWaveAtom => {
-                let qt_esds = read_qt_wave_atom(&mut b, strictness)?;
-                codec_type = qt_esds.audio_codec;
-                codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
-            }
+            BoxType::QTWaveAtom => match read_qt_wave_atom(&mut b, strictness) {
+                Ok(qt_esds) => {
+                    codec_type = qt_esds.audio_codec;
+                    codec_specific = Some(AudioCodecSpecific::ES_Descriptor(qt_esds));
+                }
+                Err(e) => {
+                    warn!("Failed to parse wave atom: {e:?}");
+                }
+            },
             BoxType::ProtectionSchemeInfoBox => {
                 if name != BoxType::ProtectedAudioSampleEntry {
                     return Status::StsdBadAudioSampleEntry.into();


### PR DESCRIPTION
Updated version of #420 

Sample file with unknown video codec: 
https://drive.google.com/file/d/1DS7u06qy_6dS2wYwK45lscAn_ZnF4e_x/view?usp=sharing

Sample file with unknown atoms in the wave atom:
https://drive.google.com/file/d/1NbX5QlSR8BLuHK2uj0lm14yJ0DJ3jT4H/view?usp=sharing

This PR changes the behavior of the parsing of wave atom and video_sample_entry such that it doesn't fail when that atom contains unknown (not implemented) boxes and codecs.

Instead of failing to parse the entire file, just skip that box and leave codec_specific as None. 

If ParseStrictness is Strict, the behavior is not changed, the parser will fail