### PR TITLE
Add a safe wrapper for image_mirror_ptr()

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -1721,6 +1721,15 @@ impl AvifContext {
         }
     }
 
+    pub fn image_mirror(&self) -> Result<Option<ImageMirror>> {
+        let mirror_ptr = self.image_mirror_ptr()?;
+        if mirror_ptr.is_null() {
+            Ok(None)
+        } else {
+            unsafe { Ok(Some(std::ptr::read_unaligned(mirror_ptr))) }
+        }
+    }
+
     pub fn image_mirror_ptr(&self) -> Result<*const ImageMirror> {
         if let Some(primary_item) = &self.primary_item {
             match self


### PR DESCRIPTION
This is needed for adding AVIF orientation support to the `image` crate: https://github.com/image-rs/image/pull/2750

I'm using `ptr::read_unaligned` as a hedge against future changes, the struct is 1 byte anyway so this doesn't matter either way. I'm happy to change it to `ptr::read` if you prefer.