### PR TITLE
Minor FFI hardening fixes

### DIFF
--- a/mp4parse/src/lib.rs
+++ b/mp4parse/src/lib.rs
@@ -3908,8 +3908,10 @@ fn read_colr<T: Read>(
 /// Rotation in the positive (that is, anticlockwise) direction
 /// Visualized in terms of starting with (⥠) UPWARDS HARPOON WITH BARB LEFT FROM BAR
 /// similar to a DIGIT ONE (1)
+#[derive(Default)]
 pub enum ImageRotation {
     /// ⥠ UPWARDS HARPOON WITH BARB LEFT FROM BAR
+    #[default]
     D0,
     /// ⥞ LEFTWARDS HARPOON WITH BARB DOWN FROM BAR
     D90,

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -543,6 +543,10 @@ impl Read for Mp4parseIo {
         }
         let rv = self.read.unwrap()(buf.as_mut_ptr(), buf.len(), self.userdata);
         if rv >= 0 {
+            assert!(
+                rv as usize <= buf.len(),
+                "read callback returned more bytes than buffer size"
+            );
             Ok(rv as usize)
         } else {
             Err(std::io::Error::other("I/O error in Mp4parseIo Read impl"))

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -875,8 +875,12 @@ fn get_track_audio_info(
                 }
             }
         };
-        sample_info.channels = audio.channelcount as u16;
+        sample_info.channels =
+            u16::try_from(audio.channelcount).map_err(|_| Mp4parseStatus::Invalid)?;
         sample_info.bit_depth = audio.samplesize;
+        if audio.samplerate < 0.0 || audio.samplerate > u32::MAX as f64 {
+            return Err(Mp4parseStatus::Invalid);
+        }
         sample_info.sample_rate = audio.samplerate as u32;
         // sample_info.profile is handled below on a per case basis
 

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -724,7 +724,10 @@ pub unsafe extern "C" fn mp4parse_get_track_info(
     let track = &context.tracks[track_index];
 
     if let (Some(timescale), Some(context_timescale)) = (track.timescale, context.timescale) {
-        info.time_scale = timescale.0 as u32;
+        info.time_scale = match timescale.0.try_into() {
+            Ok(v) => v,
+            Err(_) => return Mp4parseStatus::Invalid,
+        };
         let media_time: CheckedInteger<u64> = track
             .media_time
             .map_or(0.into(), |media_time| media_time.0.into());

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -385,7 +385,7 @@ pub enum Mp4parseAvifLoopMode {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Mp4parseAvifInfo {
     pub premultiplied_alpha: bool,
     pub major_brand: [u8; 4],
@@ -427,7 +427,7 @@ pub struct Mp4parseAvifInfo {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Mp4parseAvifImage {
     pub primary_image: Mp4parseByteData,
     /// If no alpha item exists, members' `.length` will be 0 and `.data` will be null
@@ -1240,6 +1240,9 @@ pub unsafe extern "C" fn mp4parse_avif_get_info(
         return Mp4parseStatus::BadArg;
     }
 
+    // Initialize fields to default values to ensure all fields are always valid.
+    *avif_info = Default::default();
+
     if let Ok(info) = mp4parse_avif_get_info_safe((*parser).context()) {
         *avif_info = info;
         Mp4parseStatus::Ok
@@ -1421,6 +1424,9 @@ pub unsafe extern "C" fn mp4parse_avif_get_image(
     if parser.is_null() || avif_image.is_null() {
         return Mp4parseStatus::BadArg;
     }
+
+    // Initialize fields to default values to ensure all fields are always valid.
+    *avif_image = Default::default();
 
     if let Ok(image) = mp4parse_avif_get_image_safe(&*parser) {
         *avif_image = image;

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -345,6 +345,11 @@ pub struct Mp4parseFragmentInfo {
 
 /// Parser state for MP4 files, exposed to C callers via raw pointer.
 ///
+/// # Thread safety
+///
+/// A parser instance must not be accessed from multiple threads
+/// concurrently. The caller is responsible for serializing all access.
+///
 /// # Pointer stability
 ///
 /// Several C API functions return raw pointers into data cached on this
@@ -475,6 +480,12 @@ impl ContextParser for Mp4parseParser {
     }
 }
 
+/// Parser state for AVIF files, exposed to C callers via raw pointer.
+///
+/// # Thread safety
+///
+/// A parser instance must not be accessed from multiple threads
+/// concurrently. The caller is responsible for serializing all access.
 #[derive(Default)]
 pub struct Mp4parseAvifParser {
     context: AvifContext,

--- a/mp4parse_capi/src/lib.rs
+++ b/mp4parse_capi/src/lib.rs
@@ -1456,7 +1456,7 @@ pub unsafe extern "C" fn mp4parse_get_indice_table(
     track_id: u32,
     indices: *mut Mp4parseByteData,
 ) -> Mp4parseStatus {
-    if parser.is_null() {
+    if parser.is_null() || indices.is_null() {
         return Mp4parseStatus::BadArg;
     }
 
@@ -1635,7 +1635,7 @@ pub unsafe extern "C" fn mp4parse_is_fragmented(
     track_id: u32,
     fragmented: *mut u8,
 ) -> Mp4parseStatus {
-    if parser.is_null() {
+    if parser.is_null() || fragmented.is_null() {
         return Mp4parseStatus::BadArg;
     }
 


### PR DESCRIPTION
Tiny defensive changes:

- avoid exposing invalid heap pointers to FFI if the cache insert fails.  The caller would've still received an error and should not expect the pointers to be valid, but it's better to avoid exposing them in this error case.
- init `avif_info` and `avif_image` with defaults to match other code and avoid exposing uninitialized structs on error paths
- make sample_info conversion failure explicit rather than silent
- add missing nullptr checks in some FFI functions
- avoid truncating `timescale` silently
- add an assert to catch `read` callback misbehaviour

